### PR TITLE
fix & update duel.AnnounceLevel

### DIFF
--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3198,9 +3198,11 @@ int32 scriptlib::duel_announce_level(lua_State * L) {
 		for (int32 i = min; i <= max; ++i) {
 			int32 chk = 1;
 			for (int32 j = 4; j <= lua_gettop(L); ++j) {
-				int32 ex = lua_tointeger(L, j);
-				if (ex == i && !lua_isnil(L,j))
-					chk = 0;
+				if (!lua_isnil(L, j)) {
+					int32 ex = lua_tointeger(L, j);
+					if (ex == i)
+						chk = 0;
+				}
 			}
 			if (chk == 1) {
 				count += 1;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3199,7 +3199,7 @@ int32 scriptlib::duel_announce_level(lua_State * L) {
 			int32 chk = 1;
 			for (int32 j = 4; j <= lua_gettop(L); ++j) {
 				int32 ex = lua_tointeger(L, j);
-				if (ex == i)
+				if (ex == i && !lua_isnil(L,j))
 					chk = 0;
 			}
 			if (chk == 1) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3179,8 +3179,42 @@ int32 scriptlib::duel_announce_attribute(lua_State * L) {
 int32 scriptlib::duel_announce_level(lua_State * L) {
 	check_action_permission(L);
 	check_param_count(L, 1);
-	int32 playerid = lua_tonumberint(L, 1);
+	int32 playerid = lua_tointeger(L, 1);
+	int32 min = 1;
+	int32 max = 12;
+	if (lua_gettop(L) >= 2 && !lua_isnil(L, 2))
+		min = lua_tointeger(L, 2);
+	if (lua_gettop(L) >= 3 && !lua_isnil(L, 3))
+		max = lua_tointeger(L, 3);
+	if (min > max) {
+		int32 aux = max;
+		max = min;
+		min = aux;
+	}
 	duel* pduel = interpreter::get_duel_info(L);
+	pduel->game_field->core.select_options.clear();
+	int32 count = 0;
+	if (lua_gettop(L) > 3) {
+		for (int32 i = min; i <= max; ++i) {
+			int32 chk = 1;
+			for (int32 j = 4; j <= lua_gettop(L); ++j) {
+				int32 ex = lua_tointeger(L, j);
+				if (ex == i)
+					chk = 0;
+			}
+			if (chk == 1) {
+				count += 1;
+				pduel->game_field->core.select_options.push_back(i);
+			}
+		}
+	} else {
+		for (int32 i = min; i <= max; ++i) {
+			count += 1;
+			pduel->game_field->core.select_options.push_back(i);
+		}
+	}
+	if (count == 0)
+		return 0;
 	pduel->game_field->add_process(PROCESSOR_ANNOUNCE_NUMBER, 0, 0, 0, playerid + 0x10000, 0xc0001);
 	return lua_yield(L, 0);
 }


### PR DESCRIPTION
fixed the problem from empty list and updated it, now it have that syntax.
Duel.AnnounceLevel(int player[,int min = 1, int max = 12, int exception = nil, ...])
where player declare from a level (number) from min to max, with exception of some (list).