### PR TITLE
fix all warnings under gcc, enable all warnings

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1085,14 +1085,14 @@ uint32 card::get_link() {
 		return data.level;
 	if (temp.level != 0xffffffff)
 		return temp.level;
-		effect_set effects;
-		int32 link = data.level;
-		temp.level = link;
-		int32 up = 0, upc = 0;
-		filter_effect(EFFECT_UPDATE_LINK, &effects, FALSE);
-		filter_effect(EFFECT_CHANGE_LINK, &effects, FALSE);
-		filter_effect(EFFECT_CHANGE_LINK_FINAL, &effects);
-		for (int32 i = 0; i < effects.size(); ++i) {
+	effect_set effects;
+	int32 link = data.level;
+	temp.level = link;
+	int32 up = 0, upc = 0;
+	filter_effect(EFFECT_UPDATE_LINK, &effects, FALSE);
+	filter_effect(EFFECT_CHANGE_LINK, &effects, FALSE);
+	filter_effect(EFFECT_CHANGE_LINK_FINAL, &effects);
+	for (int32 i = 0; i < effects.size(); ++i) {
 		switch (effects[i]->code) {
 		case EFFECT_UPDATE_LINK:
 			if ((effects[i]->type & EFFECT_TYPE_SINGLE) && !effects[i]->is_flag(EFFECT_FLAG_SINGLE_RANGE))
@@ -1119,7 +1119,7 @@ uint32 card::get_link() {
 	return link;		
 }
 uint32 card::get_synchro_level(card* pcard) {
-	if(((data.type & TYPE_XYZ) || (status & STATUS_NO_LEVEL) && !(is_affected_by_effect(EFFECT_RANK_LEVEL) || is_affected_by_effect(EFFECT_RANK_LEVEL_S)))
+	if(((data.type & TYPE_XYZ) || ((status & STATUS_NO_LEVEL) && !(is_affected_by_effect(EFFECT_RANK_LEVEL) || is_affected_by_effect(EFFECT_RANK_LEVEL_S))))
 	|| (data.type & TYPE_LINK))
 		return 0;
 	uint32 lev;
@@ -1132,7 +1132,7 @@ uint32 card::get_synchro_level(card* pcard) {
 	return lev;
 }
 uint32 card::get_ritual_level(card* pcard) {
-	if(((data.type & TYPE_XYZ) || (status & STATUS_NO_LEVEL) && !(is_affected_by_effect(EFFECT_RANK_LEVEL) || is_affected_by_effect(EFFECT_RANK_LEVEL_S)))
+	if(((data.type & TYPE_XYZ) || ((status & STATUS_NO_LEVEL) && !(is_affected_by_effect(EFFECT_RANK_LEVEL) || is_affected_by_effect(EFFECT_RANK_LEVEL_S))))
 	|| (data.type & TYPE_LINK))
 		return 0;
 	uint32 lev;
@@ -1668,7 +1668,7 @@ uint32 card::get_column_zone(int32 loc1, int32 left, int32 right) {
 	int32 zones = 0;
 	int32 loc2 = current.location;
 	int32 s = current.sequence;
-	if(!(loc1 & LOCATION_ONFIELD) || !(loc2 & LOCATION_ONFIELD) || loc2 == LOCATION_SZONE && s >=5 || left < 0 || right < 0)
+	if(!(loc1 & LOCATION_ONFIELD) || !(loc2 & LOCATION_ONFIELD) || (loc2 == LOCATION_SZONE && s >= 5) || left < 0 || right < 0)
 		return 0;
 	if(s <= 4) {
 		if(loc1 != loc2)
@@ -1736,7 +1736,7 @@ int32 card::is_all_column() {
 		return FALSE;
 	card_set cset;
 	get_column_cards(&cset, 0, 0);
-	int32 full = 3;
+	uint32 full = 3;
 	if((pduel->game_field->core.duel_options & DUEL_EMZONE) && (current.sequence == 1 || current.sequence == 3))
 		full++;
 	if(cset.size() == full)
@@ -2842,11 +2842,13 @@ int32 card::check_set_procedure(effect* peffect, uint8 playerid, uint8 ignore_co
 		return FALSE;
 	if(!pduel->game_field->is_player_can_mset(peffect->get_value(this), playerid, this))
 		return FALSE;
+	/*
 	uint8 toplayer = playerid;
 	if(peffect->is_flag(EFFECT_FLAG_SPSUM_PARAM)) {
 		if(peffect->o_range)
 			toplayer = 1 - playerid;
 	}
+	*/ // UNUSED VARIABLE
 	if(!ignore_count && !pduel->game_field->core.extra_summon[playerid]
 			&& pduel->game_field->core.summon_count[playerid] >= pduel->game_field->get_summon_count_limit(playerid)) {
 		effect_set eset;
@@ -2990,7 +2992,7 @@ effect* card::is_affected_by_effect(int32 code, card* target) {
 	}
 	return 0;
 }
-int32 card::get_card_effect(int32 code) {
+int32 card::get_card_effect(uint32 code) {
 	effect* peffect;
 	int32 i = 0;
 	for (auto rg = single_effect.begin(); rg != single_effect.end(); ++rg) {
@@ -3592,7 +3594,7 @@ int32 card::is_destructable_by_effect(effect* peffect, uint8 playerid) {
 			pduel->lua->add_param(REASON_EFFECT, PARAM_TYPE_INT);
 			pduel->lua->add_param(playerid, PARAM_TYPE_INT);
 			int32 ct;
-			if(ct = eset[i]->get_value(3)) {
+			if((ct = eset[i]->get_value(3))) {
 				auto it = indestructable_effects.insert(std::make_pair(eset[i]->id, 0));
 				if(it.first->second + 1 <= ct) {
 					return FALSE;

--- a/card.h
+++ b/card.h
@@ -286,7 +286,7 @@ public:
 	void filter_spsummon_procedure_g(uint8 playerid, effect_set* eset);
 	effect* is_affected_by_effect(int32 code);
 	effect* is_affected_by_effect(int32 code, card* target);
-	int32 get_card_effect(int32 code);
+	int32 get_card_effect(uint32 code);
 	effect* check_control_effect();
 	int32 fusion_check(group* fusion_m, group* cg, uint32 chkf);
 	void fusion_filter_valid(group* fusion_m, group* cg, uint32 chkf, effect_set* eset);

--- a/effect.cpp
+++ b/effect.cpp
@@ -13,7 +13,7 @@
 
 bool effect_sort_id(const effect* e1, const effect* e2) {
 	return e1->id < e2->id;
-};
+}
 effect::effect(duel* pd) {
 	scrtype = 3;
 	ref_handle = 0;

--- a/field.cpp
+++ b/field.cpp
@@ -219,7 +219,7 @@ void field::add_card(uint8 playerid, card* pcard, uint8 location, uint8 sequence
 		break;
 	}
 	case LOCATION_EXTRA: {
-		if(player[playerid].extra_p_count == 0 || (pcard->data.type & TYPE_PENDULUM) && (pcard->sendto_param.position & POS_FACEUP))
+		if(player[playerid].extra_p_count == 0 || ((pcard->data.type & TYPE_PENDULUM) && (pcard->sendto_param.position & POS_FACEUP)))
 			player[playerid].list_extra.push_back(pcard);
 		else
 			player[playerid].list_extra.insert(player[playerid].list_extra.end() - player[playerid].extra_p_count, pcard);
@@ -2343,7 +2343,7 @@ int32 field::get_attack_target(card* pcard, card_vector* v, uint8 chain_attack) 
 					attack_tg.push_back(atarget);
 			}
 		}
-		if(is_player_affected_by_effect(p, EFFECT_SELF_ATTACK) && (!pcard->is_affected_by_effect(EFFECT_ATTACK_ALL) || !&attack_tg)) {
+		if(is_player_affected_by_effect(p, EFFECT_SELF_ATTACK) && (!pcard->is_affected_by_effect(EFFECT_ATTACK_ALL) || !attack_tg.size())) {
 			for (uint32 i = 0; i < 7; ++i) {
 				card* atarget = player[p].list_mzone[i];
 				if (atarget != core.attacker) {
@@ -2486,7 +2486,7 @@ bool field::confirm_attack_target() {
 	uint8 p = pcard->current.controler;
 	effect* peffect;
 	card_vector* pv = NULL;
-	int32 atype = 0;
+	//int32 atype = 0; // UNUSED VARIABLE
 	card_vector must_be_attack;
 	card_vector attack_tg;
 	card_vector only_be_attack;
@@ -2504,7 +2504,7 @@ bool field::confirm_attack_target() {
 	}
 	pcard->filter_effect(EFFECT_RISE_TO_FULL_HEIGHT, &eset);
 	if(eset.size()) {
-		atype = 1;
+		//atype = 1; // UNUSED VARIABLE
 		std::set<uint32> idset;
 		for(int32 i = 0; i < eset.size(); ++i)
 			idset.insert(eset[i]->label);
@@ -2513,26 +2513,26 @@ bool field::confirm_attack_target() {
 		else
 			return false;
 	} else if(pcard->is_affected_by_effect(EFFECT_ONLY_ATTACK_MONSTER)) {
-		atype = 2;
+		//atype = 2; // UNUSED VARIABLE
 		if(only_be_attack.size() == 1)
 			pv = &only_be_attack;
 		else
 			return false;
 	} else if(pcard->is_affected_by_effect(EFFECT_MUST_ATTACK_MONSTER)) {
-		atype = 3;
+		//atype = 3; // UNUSED VARIABLE
 		if(must_be_attack.size())
 			pv = &must_be_attack;
 		else
 			return false;
 	} else {
-		atype = 4;
+		//atype = 4; // UNUSED VARIABLE
 		for (uint32 i = 0; i < 7; ++i) {
 			card* atarget = player[1 - p].list_mzone[i];
 			if (atarget != core.attacker) {
 				attack_tg.push_back(atarget);
 			}
 		}
-		if(is_player_affected_by_effect(p, EFFECT_SELF_ATTACK) && (!pcard->is_affected_by_effect(EFFECT_ATTACK_ALL) || !&attack_tg)) {
+		if(is_player_affected_by_effect(p, EFFECT_SELF_ATTACK) && (!pcard->is_affected_by_effect(EFFECT_ATTACK_ALL) || !attack_tg.size())) {
 			for (uint32 i = 0; i < 7; ++i) {
 				card* atarget = player[p].list_mzone[i];
 				if (atarget != core.attacker) {
@@ -3024,7 +3024,7 @@ int32 field::is_player_can_remove(uint8 playerid, card * pcard) {
 }
 int32 field::is_chain_negatable(uint8 chaincount) {
 	effect_set eset;
-	if(chaincount < 0 || chaincount > core.current_chain.size())
+	if(chaincount > core.current_chain.size())
 		return FALSE;
 	effect* peffect;
 	if(chaincount == 0)
@@ -3043,7 +3043,7 @@ int32 field::is_chain_negatable(uint8 chaincount) {
 }
 int32 field::is_chain_disablable(uint8 chaincount) {
 	effect_set eset;
-	if(chaincount < 0 || chaincount > core.current_chain.size())
+	if(chaincount > core.current_chain.size())
 		return FALSE;
 	effect* peffect;
 	if(chaincount == 0)
@@ -3063,7 +3063,7 @@ int32 field::is_chain_disablable(uint8 chaincount) {
 	return TRUE;
 }
 int32 field::is_chain_disabled(uint8 chaincount) {
-	if(chaincount < 0 || chaincount > core.current_chain.size())
+	if(chaincount > core.current_chain.size())
 		return FALSE;
 	chain* pchain;
 	if(chaincount == 0)
@@ -3084,7 +3084,7 @@ int32 field::is_chain_disabled(uint8 chaincount) {
 	return FALSE;
 }
 int32 field::check_chain_target(uint8 chaincount, card * pcard) {
-	if(chaincount < 0 || chaincount > core.current_chain.size())
+	if(chaincount > core.current_chain.size())
 		return FALSE;
 	chain* pchain;
 	if(chaincount == 0)
@@ -3140,7 +3140,7 @@ int32 field::get_cteffect(effect* peffect, int32 playerid, int32 store) {
 		if(!feffect->in_range(phandler))
 			continue;
 		uint32 code = efit->first;
-		if(code == EVENT_FREE_CHAIN || code == EVENT_PHASE + infos.phase) {
+		if(code == EVENT_FREE_CHAIN || code == EVENT_PHASE + (uint32)infos.phase) {
 			nil_event.event_code = code;
 			if(get_cteffect_evt(feffect, playerid, nil_event, store) && !store)
 				return TRUE;

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -845,7 +845,7 @@ int32 interpreter::call_function(int32 f, uint32 param_count, int32 ret_count) {
 		return OPERATION_FAIL;
 	}
 	if (param_count != params.size()) {
-		sprintf(pduel->strbuffer, "\"CallFunction\": incorrect parameter count (%d expected, %ud pushed)", param_count, params.size());
+		sprintf(pduel->strbuffer, "\"CallFunction\": incorrect parameter count (%d expected, %ud pushed)", param_count, (uint32)params.size());
 		handle_message(pduel, 1);
 		params.clear();
 		return OPERATION_FAIL;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -1522,8 +1522,8 @@ int32 scriptlib::duel_change_attack_target(lua_State *L) {
 	field::card_vector cv;
 	pduel->game_field->get_attack_target(attacker, &cv, pduel->game_field->core.chain_attack);
 	auto turnp = pduel->game_field->infos.turn_player;
-	if((target && std::find(cv.begin(), cv.end(), target) != cv.end() || ignore)
-			|| !target && !attacker->is_affected_by_effect(EFFECT_CANNOT_DIRECT_ATTACK)) {
+	if(((target && std::find(cv.begin(), cv.end(), target) != cv.end()) || ignore) ||
+		(!target && !attacker->is_affected_by_effect(EFFECT_CANNOT_DIRECT_ATTACK))) {
 		pduel->game_field->core.attack_target = target;
 		pduel->game_field->core.attack_rollback = FALSE;
 		pduel->game_field->core.opp_mzone.clear();

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -123,7 +123,7 @@ int32 scriptlib::group_take_at_pos(lua_State *L) {
 	check_param(L, PARAM_TYPE_GROUP, 1);
 	group* pgroup = *(group**)lua_touserdata(L, 1);
 	int32 pos = lua_tonumberint(L, 2);
-	if(pos > pgroup->container.size())
+	if(pos > (int32)pgroup->container.size())
 		lua_pushnil(L);
 	else {
 		auto cit = pgroup->container.begin();

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -44,7 +44,7 @@ byte* default_script_reader(const char* script_name, int* slen) {
 	fp = fopen(script_name, "rb");
 	if (!fp)
 		return 0;
-	int len = fread(buffer, 1, sizeof(buffer), fp);
+	size_t len = fread(buffer, 1, sizeof(buffer), fp);
 	fclose(fp);
 	if(len >= sizeof(buffer))
 		return 0;
@@ -108,8 +108,8 @@ extern "C" DECL_DLLEXPORT void start_duel(ptr pduel, int32 options) {
 	}
 	if (options & DUEL_RELAY_MODE) {
 		for (int p = 0; p < 2; p++)
-			for (int l = 0; l < pd->game_field->player[p].relay_list_main.size(); l++)
-				for (int i = 0; i < pd->game_field->player[p].start_count && pd->game_field->player[p].relay_list_main[l].size(); ++i) {
+			for (size_t l = 0; l < pd->game_field->player[p].relay_list_main.size(); l++)
+				for (size_t i = 0; i < (size_t)pd->game_field->player[p].start_count && pd->game_field->player[p].relay_list_main[l].size(); ++i) {
 					if (pd->game_field->player[p].relay_list_hand.size() == l)
 						pd->game_field->player[p].relay_list_hand.push_back(std::vector<card*>());
 					card* pcard = pd->game_field->player[p].relay_list_main[l].back();

--- a/operations.cpp
+++ b/operations.cpp
@@ -1545,7 +1545,7 @@ int32 field::summon(uint16 step, uint8 sumplayer, card* target, effect* proc, ui
 				std::vector<int32> retval;
 				eset[i]->get_value(target, 0, &retval);
 				int32 new_min_tribute = retval.size() > 0 ? retval[0] : 0;
-				int32 new_zone = retval.size() > 1 ? retval[1] : 0x1f;
+				uint32 new_zone = retval.size() > 1 ? retval[1] : 0x1f;
 				int32 releasable = retval.size() > 2 ? (retval[2] < 0 ? 0xff00ff - retval[2] : retval[2]) : 0xff00ff;
 				new_zone &= zone;
 				bool unchanged = (new_zone == zone);
@@ -2095,7 +2095,7 @@ int32 field::mset(uint16 step, uint8 setplayer, card* target, effect* proc, uint
 				std::vector<int32> retval;
 				eset[i]->get_value(target, 0, &retval);
 				int32 new_min_tribute = retval.size() > 0 ? retval[0] : 0;
-				int32 new_zone = retval.size() > 1 ? retval[1] : 0x1f;
+				uint32 new_zone = retval.size() > 1 ? retval[1] : 0x1f;
 				int32 releasable = retval.size() > 2 ? (retval[2] < 0 ? 0xff00ff - retval[2] : retval[2]) : 0xff00ff;
 				new_zone &= zone;
 				bool unchanged = (new_zone == zone);
@@ -3180,7 +3180,7 @@ int32 field::destroy(uint16 step, group * targets, effect * reason_effect, uint3
 						pduel->lua->add_param(pcard->current.reason, PARAM_TYPE_INT);
 						pduel->lua->add_param(pcard->current.reason_player, PARAM_TYPE_INT);
 						int32 ct;
-						if(ct = eset[i]->get_value(3)) {
+						if((ct = eset[i]->get_value(3))) {
 							auto it = pcard->indestructable_effects.insert(std::make_pair(eset[i]->id, 0));
 							if(++it.first->second <= ct) {
 								indestructable_effect_set.insert(eset[i]);
@@ -3383,7 +3383,7 @@ int32 field::destroy(uint16 step, group * targets, effect * reason_effect, uint3
 						pduel->lua->add_param(pcard->current.reason, PARAM_TYPE_INT);
 						pduel->lua->add_param(pcard->current.reason_player, PARAM_TYPE_INT);
 						int32 ct;
-						if(ct = eset[i]->get_value(3)) {
+						if((ct = eset[i]->get_value(3))) {
 							auto it = pcard->indestructable_effects.insert(std::make_pair(eset[i]->id, 0));
 							if(++it.first->second <= ct) {
 								pduel->write_buffer8(MSG_HINT);
@@ -4179,7 +4179,7 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 		returns.ivalue[0] = FALSE;
 		if((ret == 1) && (!(target->current.reason & REASON_TEMPORARY) || (target->current.reason_effect->owner != core.reason_effect->owner)))
 			return TRUE;
-		if(location == LOCATION_SZONE && ((!is_equip && (target->data.type & TYPE_FIELD) && (target->data.type & TYPE_SPELL|TYPE_TRAP) && zone==0xff) || (zone & 0x20 && zone != 0xff))) {
+		if(location == LOCATION_SZONE && ((!is_equip && (target->data.type & TYPE_FIELD) && (target->data.type & (TYPE_SPELL|TYPE_TRAP)) && zone==0xff) || (zone & 0x20 && zone != 0xff))) {
 			card* pcard = get_field_card(playerid, LOCATION_SZONE, 5);
 			if(pcard) {
 				if(!(pduel->game_field->core.duel_options & DUEL_1_FIELD))
@@ -4208,11 +4208,15 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 			uint32 flag;
 			uint32 lreason = (target->current.location == LOCATION_MZONE) ? LOCATION_REASON_CONTROL : LOCATION_REASON_TOFIELD;
 			int32 ct = get_useable_count(target, playerid, location, move_player, lreason, zone, &flag);
-			if (location == LOCATION_MZONE && zone & 0x60 && zone!=0xff && !rule) {
-				if (zone & 0x20 && pduel->game_field->is_location_useable(playerid, location, 5))
-					flag = flag & ~(1u << 5); ct++;
-				if (zone & 0x40 && pduel->game_field->is_location_useable(playerid, location, 6))
-					flag = flag & ~(1u << 6); ct++;
+			if (location == LOCATION_MZONE && (zone & 0x60) && (zone!=0xff) && !rule) {
+				if ((zone & 0x20) && pduel->game_field->is_location_useable(playerid, location, 5)){
+					flag = flag & ~(1u << 5);
+					ct++;
+				}
+				if ((zone & 0x40) && pduel->game_field->is_location_useable(playerid, location, 6)){
+					flag = flag & ~(1u << 6);
+					ct++;
+				}
 			}
 			if (location == LOCATION_SZONE)
 				flag = flag | ~zone;
@@ -4246,7 +4250,7 @@ int32 field::move_to_field(uint16 step, card* target, uint32 enable, uint32 ret,
 	}
 	case 1: {
 		uint32 seq = returns.bvalue[2];
-		if (location == LOCATION_SZONE && ((!is_equip && (target->data.type & TYPE_FIELD) && (target->data.type & TYPE_SPELL | TYPE_TRAP) && zone==0xff) || (zone & 0x20 && zone !=0xff)))
+		if (location == LOCATION_SZONE && ((!is_equip && (target->data.type & TYPE_FIELD) && (target->data.type & (TYPE_SPELL | TYPE_TRAP)) && zone==0xff) || (zone & 0x20 && zone !=0xff)))
 			seq = 5;
 		if(ret != 1) {
 			if(location != target->current.location) {

--- a/playerop.cpp
+++ b/playerop.cpp
@@ -60,11 +60,11 @@ int32 field::select_battle_command(uint16 step, uint8 playerid) {
 	} else {
 		uint32 t = returns.ivalue[0] & 0xffff;
 		uint32 s = returns.ivalue[0] >> 16;
-		if(t < 0 || t > 3 || s < 0
-		        || (t == 0 && s >= core.select_chains.size())
-		        || (t == 1 && s >= core.attackable_cards.size())
-		        || (t == 2 && !core.to_m2)
-		        || (t == 3 && !core.to_ep)) {
+		if(t > 3
+		   || (t == 0 && s >= core.select_chains.size())
+		   || (t == 1 && s >= core.attackable_cards.size())
+		   || (t == 2 && !core.to_m2)
+		   || (t == 3 && !core.to_ep)) {
 			pduel->write_buffer8(MSG_RETRY);
 			return FALSE;
 		}
@@ -155,16 +155,16 @@ int32 field::select_idle_command(uint16 step, uint8 playerid) {
 	} else {
 		uint32 t = returns.ivalue[0] & 0xffff;
 		uint32 s = returns.ivalue[0] >> 16;
-		if(t < 0 || t > 8 || s < 0
-		        || (t == 0 && s >= core.summonable_cards.size())
-		        || (t == 1 && s >= core.spsummonable_cards.size())
-		        || (t == 2 && s >= core.repositionable_cards.size())
-		        || (t == 3 && s >= core.msetable_cards.size())
-		        || (t == 4 && s >= core.ssetable_cards.size())
-		        || (t == 5 && s >= core.select_chains.size())
-		        || (t == 6 && (infos.phase != PHASE_MAIN1 || !core.to_bp))
-		        || (t == 7 && !core.to_ep)
-		        || (t == 8 && !(infos.can_shuffle && player[playerid].list_hand.size() > 1))) {
+		if(t > 8
+		   || (t == 0 && s >= core.summonable_cards.size())
+		   || (t == 1 && s >= core.spsummonable_cards.size())
+		   || (t == 2 && s >= core.repositionable_cards.size())
+		   || (t == 3 && s >= core.msetable_cards.size())
+		   || (t == 4 && s >= core.ssetable_cards.size())
+		   || (t == 5 && s >= core.select_chains.size())
+		   || (t == 6 && (infos.phase != PHASE_MAIN1 || !core.to_bp))
+		   || (t == 7 && !core.to_ep)
+		   || (t == 8 && !(infos.can_shuffle && player[playerid].list_hand.size() > 1))) {
 			pduel->write_buffer8(MSG_RETRY);
 			return FALSE;
 		}
@@ -278,7 +278,7 @@ int32 field::select_card(uint16 step, uint8 playerid, uint8 cancelable, uint8 mi
 		uint8 m = core.select_cards.size(), v = 0;
 		for(int32 i = 0; i < returns.bvalue[0]; ++i) {
 			v = returns.bvalue[i + 1];
-			if(v < 0 || v >= m || v >= 63 || c[v]) {
+			if(v >= m || v >= 63 || c[v]) {
 				pduel->write_buffer8(MSG_RETRY);
 				return FALSE;
 			}
@@ -328,7 +328,7 @@ int32 field::select_unselect_card(uint16 step, uint8 playerid, uint8 cancelable,
 		uint8 m = core.select_cards.size() + core.unselect_cards.size(), v = 0;
 		for (int32 i = 0; i < returns.bvalue[0]; ++i) {
 			v = returns.bvalue[i + 1];
-			if (v < 0 || v >= m || v >= 63 || c[v]) {
+			if (v >= m || v >= 63 || c[v]) {
 				pduel->write_buffer8(MSG_RETRY);
 				return FALSE;
 			}
@@ -492,7 +492,7 @@ int32 field::select_position(uint16 step, uint8 playerid, uint32 code, uint8 pos
 		return FALSE;
 	} else {
 		uint32 pos = returns.ivalue[0];
-		if(pos != 0x1 && pos != 0x2 && pos != 0x4 && pos != 0x8 || !(pos & positions)) {
+		if((pos != 0x1 && pos != 0x2 && pos != 0x4 && pos != 0x8) || !(pos & positions)) {
 			pduel->write_buffer8(MSG_RETRY);
 			return FALSE;
 		}
@@ -543,7 +543,7 @@ int32 field::select_tribute(uint16 step, uint8 playerid, uint8 cancelable, uint8
 		uint8 m = core.select_cards.size(), v = 0, tt = 0;
 		for(int32 i = 0; i < returns.bvalue[0]; ++i) {
 			v = returns.bvalue[i + 1];
-			if(v < 0 || v >= m || v >= 6 || c[v]) {
+			if(v >= m || v >= 6 || c[v]) {
 				pduel->write_buffer8(MSG_RETRY);
 				return FALSE;
 			}
@@ -934,7 +934,7 @@ static int32 is_declarable(card_data const& cd, const std::vector<uint64>& opcod
 		}
 		case OPCODE_ISCODE: {
 			if(stack.size() >= 1) {
-				int32 code = stack.top();
+				uint32 code = stack.top();
 				stack.pop();
 				stack.push(cd.code == code);
 			}

--- a/premake4.lua
+++ b/premake4.lua
@@ -1,10 +1,11 @@
 project "ocgcore"
-    kind "StaticLib"
+	kind "StaticLib"
 
-    files { "**.cc", "**.cpp", "**.c", "**.h" }
-    configuration "windows"
-        includedirs { ".." }
-    configuration "not vs*"
-        buildoptions { "-std=gnu++0x" }
-    configuration "not windows"
-        includedirs { "/usr/include/lua", "/usr/include/lua5.3", "/usr/include/lua/5.3" }
+	files { "**.cc", "**.cpp", "**.c", "**.hh", "**.hpp", "**.h" }
+	buildoptions { "-Wall", "-Wextra", "-pedantic" }
+	
+	configuration "windows"
+		includedirs { ".." }
+	configuration "not windows"
+		buildoptions { "-std=c++11", "-Wno-unused-parameter" }
+		includedirs { "/usr/include/lua", "/usr/include/lua5.3", "/usr/include/lua/5.3" }


### PR DESCRIPTION
fixes all warnings on GCC 7.3.0. Not tested
using any other compile yet, so warnings should
still be expected using different compilers.

enables all warnings for all platforms, activates
'-pedantic' mode as well as updates the c++ standard
flag for non windows compilers.

note: This commit makes the compiler ignore
the '-Wunused-parameter' warning.