### PR TITLE
Resolve macOS binary compatibility issues and reduce Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,23 +35,8 @@ matrix:
     compiler: clang
   - name: "Mojave"
     os: osx
-    osx_image: xcode10.2
-  - name: "High Sierra"
-    os: osx
-    osx_image: xcode9.4
-    deploy: false
-  - name: "Sierra"
-    os: osx
-    osx_image: xcode9.2
-    deploy: false
-  - name: "El Capitan"
-    os: osx
-    osx_image: xcode8
-    deploy: false
-  allow_failures:
-  - name: "Sierra"
-  - name: "El Capitan"
-  fast_finish: true
+    osx_image: xcode10.3
+    env: MACOSX_DEPLOYMENT_TARGET=10.11
 before_install:
 - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then 
     curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-windows.zip;

--- a/premake5.lua
+++ b/premake5.lua
@@ -11,9 +11,6 @@ local ocgcore_config=function()
 	filter "system:not windows"
 		buildoptions { "-std=c++14", "-Wno-unused-parameter", "-pedantic" }
 
-	filter "system:bsd"
-		defines "LUA_USE_POSIX"
-
 	filter "system:macosx"
 		defines "LUA_USE_MACOSX"
 
@@ -31,10 +28,6 @@ if not subproject then
 	
 	filter "system:windows"
 		defines { "WIN32", "_WIN32", "NOMINMAX" }
-	
-	filter "system:bsd"
-		includedirs "/usr/local/include"
-		libdirs "/usr/local/lib"
 	
 	filter "system:macosx"
 		toolset "clang"

--- a/premake5.lua
+++ b/premake5.lua
@@ -27,7 +27,6 @@ if not subproject then
 		defines { "WIN32", "_WIN32", "NOMINMAX" }
 	
 	filter "system:macosx"
-		toolset "clang"
 		includedirs "/usr/local/include"
 		libdirs "/usr/local/lib"
 	

--- a/premake5.lua
+++ b/premake5.lua
@@ -2,14 +2,11 @@ local ocgcore_config=function()
 	files { "**.cc", "**.cpp", "**.c", "**.hh", "**.hpp", "**.h" }
 	warnings "Extra"
 	optimize "Speed"
-
+	cppdialect "C++14"
 	defines "LUA_COMPAT_5_2"
 
-	filter "action:not vs*"
-        buildoptions "-std=c++14"
-
 	filter "system:not windows"
-		buildoptions { "-std=c++14", "-Wno-unused-parameter", "-pedantic" }
+		buildoptions { "-Wno-unused-parameter", "-pedantic" }
 
 	filter "system:macosx"
 		defines "LUA_USE_MACOSX"


### PR DESCRIPTION
- Upgrade build image to Xcode 10.3
- For all the work that went into testing, it is just one environment variable `MACOSX_DEPLOYMENT_TARGET` affecting `-mmacosx-version-min` for clang.
  - Affects both lua and ocgcore build
  - Uses default SDK path. If this becomes a problem in the future, we can install an SDK and set `SDKROOT`
- Use `cppdialect` in premake
- Removed untested BSD build configs