### PR TITLE
[Travis] C linkage for Lua, use CMake, continuous deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-build/
+[Bb]uild*/
 bin/
 obj/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 [Bb]uild*/
 bin/
 obj/
+.vscode/
+.idea/
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
   global:
   - BUILD_CONFIG=Release
   - MSBUILD_PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin"
+  - DEPLOY_DIR=ocgcore
+  - DEPLOY_BRANCH=travis-core-$TRAVIS_OS_NAME
 matrix:
   include:
   - name: "Windows 10"
@@ -19,31 +21,37 @@ matrix:
   - name: "Bionic GCC7"
     os: linux
     compiler: gcc
+    env: DEPLOY_BRANCH=travis-core-$TRAVIS_OS_NAME-$CXX
   - name: "Bionic LLVM7"
     os: linux
     compiler: clang
+    env: DEPLOY_BRANCH=travis-core-$TRAVIS_OS_NAME-$CXX
   - name: "Mojave"
     os: osx
     osx_image: xcode10.3
     env: MACOSX_DEPLOYMENT_TARGET=10.11
 install: ./travis/install-lua.sh
 script: ./travis/build-cmake.sh
-#deploy:
+before_deploy: ./travis/predeploy.sh
+deploy:
+- provider: script
+  script: bash ./travis/deploy-windows.sh
+  on:
+    condition: "$TRAVIS_OS_NAME == windows"
+- provider: pages
+  skip_cleanup: true
+  local_dir: $DEPLOY_DIR
+  github_token: $DEPLOY_TOKEN
+  repo: $DEPLOY_REPO
+  target_branch: $DEPLOY_BRANCH
+  on:
+    condition: "$TRAVIS_OS_NAME != windows" 
 #- provider: releases
 #  api_key: $OAUTH_TOKEN
-#  file:
-#  - bin/release/ocgcore.dll
-#  - bin/release/libocgcore.dylib
-#  - bin/release/libocgcore.so
-#  skip_cleanup: true
-#  draft: true
 #  overwrite: true
-#- provider: releases
-#  api_key: $OAUTH_TOKEN
-#  file:
-#  - bin/release/ocgcore.dll
-#  - bin/release/libocgcore.dylib
-#  - bin/release/libocgcore.so
 #  skip_cleanup: true
+#  file:
+#  - ocgcore-$TRAVIS_OS_NAME.zip
+#  - ocgcore-$TRAVIS_OS_NAME.tar.gz
 #  on:
 #    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ git:
   depth: 1
 env:
   global:
-  - BUILD_CONFIG=release
+  - BUILD_CONFIG=Release
   - MSBUILD_PATH="/c/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/MSBuild/15.0/Bin"
 matrix:
   include:
@@ -19,56 +19,15 @@ matrix:
   - name: "Bionic GCC7"
     os: linux
     compiler: gcc
-  - name: "Bionic LLVM/Clang"
+  - name: "Bionic LLVM7"
     os: linux
     compiler: clang
   - name: "Mojave"
     os: osx
     osx_image: xcode10.3
     env: MACOSX_DEPLOYMENT_TARGET=10.11
-before_install:
-- if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then 
-    curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-windows.zip;
-    unzip -uo premake-5.0.0-alpha14-windows.zip;
-  fi  
-- if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then 
-    curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-linux.tar.gz;
-    tar xf premake-5.0.0-alpha14-linux.tar.gz;
-  fi
-- if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then 
-    curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-macosx.tar.gz;
-    tar xf premake-5.0.0-alpha14-macosx.tar.gz;
-  fi  
-install:
-- if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then 
-    git clone --depth=1 https://github.com/Microsoft/vcpkg.git "$VCPKG_ROOT";
-    cd "$VCPKG_ROOT";
-    curl --retry 5 --connect-timeout 30 --location --remote-header-name --output installed.zip $VCPKG_CACHE_ZIP_URL;
-    unzip -uo installed.zip;
-    powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '.\bootstrap-vcpkg.bat'";
-    ./vcpkg.exe integrate install;
-    ./vcpkg.exe install $VCPKG_LIBS;
-    cd -;
-  else
-    cd /tmp;
-    curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://www.lua.org/ftp/lua-5.3.5.tar.gz;
-    tar xf lua-5.3.5.tar.gz;
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then 
-      make -Clua-5.3.5 macosx CC=$CXX;
-    else
-      make -Clua-5.3.5 linux CC=$CXX MYCFLAGS=-fPIC;
-    fi;
-    sudo make -Clua-5.3.5 install;
-    cd -;
-  fi
-script:
-- if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-    ./premake5 vs2017;
-    "$MSBUILD_PATH/msbuild.exe" -m -p:Configuration=$BUILD_CONFIG ./build/ocgcore.sln;
-  else
-    ./premake5 gmake2;
-    make -Cbuild -j2 config=$BUILD_CONFIG;
-  fi
+install: ./travis/install-lua.sh
+script: ./travis/build-cmake.sh
 #deploy:
 #- provider: releases
 #  api_key: $OAUTH_TOKEN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ set(CMAKE_CXX_STANDARD 14)
 
 project(ocgcore)
 
+if(NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE "Debug")
+endif()
+
+option(OCGCORE_MSVC_STATIC "Static CRT on Visual Studio" ON)
+
 find_package(Lua REQUIRED)
 
 add_compile_definitions(ocgcore PUBLIC LUA_COMPAT_5_2)
@@ -44,3 +50,20 @@ set(OCGCORE_SOURCE
 
 target_sources(ocgcore_static PRIVATE ${OCGCORE_SOURCE})
 target_sources(ocgcore PRIVATE ${OCGCORE_SOURCE})
+
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT ocgcore)
+if(OCGCORE_MSVC_STATIC AND MSVC)
+	set(CompilerFlags
+        CMAKE_CXX_FLAGS
+        CMAKE_CXX_FLAGS_DEBUG
+        CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_C_FLAGS
+        CMAKE_C_FLAGS_DEBUG
+        CMAKE_C_FLAGS_RELEASE
+        )
+	foreach(CompilerFlag ${CompilerFlags})
+  		string(REPLACE "/MD" "/MT" ${CompilerFlag} "${${CompilerFlag}}")
+	endforeach()
+	# CMake 3.15
+	# set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.12.0)
+set(CMAKE_CXX_STANDARD 14)
+
+project(ocgcore)
+
+find_package(Lua REQUIRED)
+
+add_compile_definitions(ocgcore PUBLIC LUA_COMPAT_5_2)
+include_directories(${LUA_INCLUDE_DIR})
+
+add_library(ocgcore_static STATIC)
+add_library(ocgcore SHARED)
+target_compile_definitions(ocgcore PUBLIC YGOPRO_BUILD_DLL)
+target_link_libraries(ocgcore PUBLIC ${LUA_LIBRARIES})
+
+set(OCGCORE_SOURCE
+	card.cpp
+	card.h
+	common.h
+	duel.cpp
+	duel.h
+	effect.cpp
+	effect.h
+	effectset.h
+	field.cpp
+	field.h
+	group.cpp
+	group.h
+	interpreter.cpp
+	interpreter.h
+	libcard.cpp
+	libdebug.cpp
+	libduel.cpp
+	libeffect.cpp
+	libgroup.cpp
+	ocgapi.cpp
+	ocgapi.h
+	operations.cpp
+	playerop.cpp
+	processor.cpp
+	progressivebuffer.h
+	scriptlib.cpp
+	scriptlib.h)
+
+target_sources(ocgcore_static PRIVATE ${OCGCORE_SOURCE})
+target_sources(ocgcore PRIVATE ${OCGCORE_SOURCE})

--- a/interpreter.h
+++ b/interpreter.h
@@ -8,9 +8,7 @@
 #ifndef INTERPRETER_H_
 #define INTERPRETER_H_
 
-#include <lua.h>
-#include <lauxlib.h>
-#include <lualib.h>
+#include <lua.hpp>
 
 #include "common.h"
 #include <unordered_map>

--- a/travis/build-cmake.sh
+++ b/travis/build-cmake.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+mkdir -p build && cd build
+if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+	cmake .. -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+        -DVCPKG_TARGET_TRIPLET=$VCPKG_DEFAULT_TRIPLET \
+        -DCMAKE_GENERATOR_PLATFORM=Win32 \
+        -DCMAKE_BUILD_TYPE=$BUILD_CONFIG
+else
+    cmake .. -DCMAKE_BUILD_TYPE=$BUILD_CONFIG
+fi
+cmake --build . --config $BUILD_CONFIG --parallel 2

--- a/travis/build-premake5.sh
+++ b/travis/build-premake5.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+	./premake5.exe vs2017;
+    "$MSBUILD_PATH/msbuild.exe" -m -p:Configuration=$BUILD_CONFIG ./build/ocgcore.sln;
+else
+	./premake5 gmake2;
+	make -Cbuild -j2 config=$BUILD_CONFIG;
+fi

--- a/travis/deploy-windows.sh
+++ b/travis/deploy-windows.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+echo Starting deployment of $DEPLOY_BRANCH to GitHub.
+cd $DEPLOY_DIR
+git init
+echo Created new local repo in $DEPLOY_DIR/
+git checkout --orphan $DEPLOY_BRANCH
+echo Orphan branch $DEPLOY_BRANCH created.
+git config user.email deploy@travis-ci.org
+git config user.name "Deployment Bot (from Travis CI)"
+echo Preparing to deploy $DEPLOY_BRANCH.
+git add -A .
+git commit -qm "Deploy $DEPLOY_REPO to $DEPLOY_REPO:$DEPLOY_BRANCH"
+git show --stat-count=10 HEAD
+echo Pushing to remote.
+git push --force https://$DEPLOY_TOKEN@github.com/$DEPLOY_REPO.git $DEPLOY_BRANCH:$DEPLOY_BRANCH

--- a/travis/install-lua.sh
+++ b/travis/install-lua.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then 
+	git clone --depth=1 https://github.com/Microsoft/vcpkg.git "$VCPKG_ROOT"
+	cd "$VCPKG_ROOT"
+	curl --retry 5 --connect-timeout 30 --location --remote-header-name --output installed.zip "$VCPKG_CACHE_ZIP_URL"
+	unzip -uo installed.zip
+	powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "& '.\bootstrap-vcpkg.bat'"
+	./vcpkg.exe integrate install;
+	./vcpkg.exe install $VCPKG_LIBS
+else
+	cd /tmp
+	curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://www.lua.org/ftp/lua-5.3.5.tar.gz
+	tar xf lua-5.3.5.tar.gz
+	cd lua-5.3.5
+	if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then 
+	  make -j2 macosx
+	else
+	  make -j2 linux MYCFLAGS=-fPIC
+	fi
+	sudo make install
+fi

--- a/travis/install-premake5.sh
+++ b/travis/install-premake5.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+	curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-windows.zip
+	unzip -uo premake-5.0.0-alpha14-windows.zip
+fi
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+	curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-linux.tar.gz
+	tar xf premake-5.0.0-alpha14-linux.tar.gz
+fi
+if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+	curl --retry 5 --connect-timeout 30 --location --remote-header-name --remote-name https://github.com/premake/premake-core/releases/download/v5.0.0-alpha14/premake-5.0.0-alpha14-macosx.tar.gz
+	tar xf premake-5.0.0-alpha14-macosx.tar.gz
+fi

--- a/travis/predeploy.sh
+++ b/travis/predeploy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+mkdir -p $DEPLOY_DIR
+cp LICENSE README.md $DEPLOY_DIR
+if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
+	mv build/$BUILD_CONFIG/ocgcore.dll build/$BUILD_CONFIG/ocgcore.lib build/$BUILD_CONFIG/ocgcore_static.lib $DEPLOY_DIR
+	powershell.exe -NoProfile -ExecutionPolicy Bypass -Command "Compress-Archive -Path $DEPLOY_DIR -DestinationPath ocgcore-$TRAVIS_OS_NAME"
+else
+	mv build/libocgcore_static.a $DEPLOY_DIR
+	if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+		mv build/libocgcore.dylib $DEPLOY_DIR
+	else
+		mv build/libocgcore.so $DEPLOY_DIR
+	fi
+	tar -zcf ocgcore-$TRAVIS_OS_NAME.tar.gz $DEPLOY_DIR
+fi


### PR DESCRIPTION
- Switch `interpreter.h` to use `lua.hpp` (C linkage) and update Travis accordingly
- Added CMakeLists, including custom configuration for Visual Studio
  - Supports configuring static or dynamic CRT
  - Mostly based on DyXel/ygopen-gui and initially generated by CLion
- Externalized Travis scripts
  - Retained premake-associated scripts for legacy purposes, but use CMake build system
- Added continuous deployment of builds
- Added tagged release binary support
- Updated .gitignore to include VSCode, CLion, CMake, and macOS support
