### PR TITLE
Don't let trigger effects trigger if their condition is met at the same time as them changing location #336

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -1866,6 +1866,8 @@ void card::xyz_remove(card* mat) {
 	if(mat->overlay_target != this)
 		return;
 	xyz_materials.erase(xyz_materials.begin() + mat->current.sequence);
+	if(pduel->game_field->core.current_chain.size() > 0)
+		pduel->game_field->core.just_sent_cards.insert(mat);
 	mat->previous.controler = mat->current.controler;
 	mat->previous.location = mat->current.location;
 	mat->previous.sequence = mat->current.sequence;

--- a/effect.cpp
+++ b/effect.cpp
@@ -272,6 +272,8 @@ int32 effect::is_activateable(uint8 playerid, const tevent& e, int32 neglect_con
 				if(phandler->is_position(POS_FACEUP) && !phandler->is_status(STATUS_EFFECT_ENABLED))
 					return FALSE;
 			}
+			if(pduel->game_field->core.just_sent_cards.find(phandler) != pduel->game_field->core.just_sent_cards.end())
+				return FALSE;
 			if(!(type & (EFFECT_TYPE_FLIP | EFFECT_TYPE_TRIGGER_F)) && !((type & EFFECT_TYPE_TRIGGER_O) && (type & EFFECT_TYPE_SINGLE))) {
 				if((code < 1132 || code > 1149) && pduel->game_field->infos.phase == PHASE_DAMAGE && !is_flag(EFFECT_FLAG_DAMAGE_STEP))
 					return FALSE;

--- a/effect.cpp
+++ b/effect.cpp
@@ -272,8 +272,6 @@ int32 effect::is_activateable(uint8 playerid, const tevent& e, int32 neglect_con
 				if(phandler->is_position(POS_FACEUP) && !phandler->is_status(STATUS_EFFECT_ENABLED))
 					return FALSE;
 			}
-			if(pduel->game_field->core.just_sent_cards.find(phandler) != pduel->game_field->core.just_sent_cards.end())
-				return FALSE;
 			if(!(type & (EFFECT_TYPE_FLIP | EFFECT_TYPE_TRIGGER_F)) && !((type & EFFECT_TYPE_TRIGGER_O) && (type & EFFECT_TYPE_SINGLE))) {
 				if((code < 1132 || code > 1149) && pduel->game_field->infos.phase == PHASE_DAMAGE && !is_flag(EFFECT_FLAG_DAMAGE_STEP))
 					return FALSE;

--- a/field.cpp
+++ b/field.cpp
@@ -285,6 +285,8 @@ void field::remove_card(card* pcard) {
 		player[playerid].used_location &= ~(1 << pcard->current.sequence);
 	if (pcard->current.location == LOCATION_SZONE)
 		player[playerid].used_location &= ~(256 << pcard->current.sequence);
+	if(core.current_chain.size() > 0)
+		core.just_sent_cards.insert(pcard);
 	pcard->previous.controler = pcard->current.controler;
 	pcard->previous.location = pcard->current.location;
 	pcard->previous.sequence = pcard->current.sequence;
@@ -351,6 +353,8 @@ void field::move_card(uint8 playerid, card* pcard, uint8 location, uint8 sequenc
 					message->write<uint32>(pcard->data.code);
 					message->write(pcard->get_info_location());
 				}
+				if(core.current_chain.size() > 0)
+					core.just_sent_cards.insert(pcard);
 				pcard->previous.controler = pcard->current.controler;
 				pcard->previous.location = pcard->current.location;
 				pcard->previous.sequence = pcard->current.sequence;
@@ -1016,12 +1020,16 @@ void field::reset_sequence(uint8 playerid, uint8 location) {
 }
 void field::swap_deck_and_grave(uint8 playerid) {
 	for(auto& pcard : player[playerid].list_grave) {
+		if(core.current_chain.size() > 0)
+			core.just_sent_cards.insert(pcard);
 		pcard->previous.location = LOCATION_GRAVE;
 		pcard->previous.sequence = pcard->current.sequence;
 		pcard->enable_field_effect(false);
 		pcard->cancel_field_effect();
 	}
 	for(auto& pcard : player[playerid].list_main) {
+		if(core.current_chain.size() > 0)
+			core.just_sent_cards.insert(pcard);
 		pcard->previous.location = LOCATION_DECK;
 		pcard->previous.sequence = pcard->current.sequence;
 		pcard->enable_field_effect(false);

--- a/field.h
+++ b/field.h
@@ -179,6 +179,7 @@ struct processor {
 	processor_list units;
 	processor_list subunits;
 	processor_unit reserved;
+	card_set just_sent_cards;
 	card_vector select_cards;
 	card_vector unselect_cards;
 	card_vector summonable_cards;

--- a/field.h
+++ b/field.h
@@ -529,7 +529,7 @@ public:
 	void solve_continuous(uint8 playerid, effect* peffect, const tevent& e);
 	int32 solve_continuous(uint16 step);
 	int32 solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2);
-	int32 break_effect();
+	int32 break_effect(bool clear_sent = true);
 	void adjust_instant();
 	void adjust_all();
 	void refresh_location_info_instant();

--- a/operations.cpp
+++ b/operations.cpp
@@ -400,6 +400,8 @@ int32 field::draw(uint16 step, effect* reason_effect, uint32 reason, uint8 reaso
 			pcard->enable_field_effect(false);
 			pcard->cancel_field_effect();
 			player[playerid].list_main.pop_back();
+			if(core.current_chain.size() > 0)
+				core.just_sent_cards.insert(pcard);
 			pcard->previous.controler = pcard->current.controler;
 			pcard->previous.location = pcard->current.location;
 			pcard->previous.sequence = pcard->current.sequence;
@@ -4130,6 +4132,8 @@ int32 field::send_to(uint16 step, group* targets, effect* reason_effect, uint32 
 			message->write(pcard->get_info_location());
 			message->write(loc_info{});
 			message->write<uint32>(pcard->current.reason);
+			if(core.current_chain.size() > 0)
+				core.just_sent_cards.insert(pcard);
 			pcard->previous.controler = pcard->current.controler;
 			pcard->previous.location = pcard->current.location;
 			pcard->previous.sequence = pcard->current.sequence;
@@ -4472,6 +4476,8 @@ int32 field::discard_deck(uint16 step, uint8 playerid, uint8 count, uint32 reaso
 			pcard->enable_field_effect(false);
 			pcard->cancel_field_effect();
 			player[playerid].list_main.pop_back();
+			if(core.current_chain.size() > 0)
+				core.just_sent_cards.insert(pcard);
 			pcard->previous.controler = pcard->current.controler;
 			pcard->previous.location = pcard->current.location;
 			pcard->previous.sequence = pcard->current.sequence;

--- a/processor.cpp
+++ b/processor.cpp
@@ -4930,6 +4930,7 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 		return FALSE;
 	}
 	case 13: {
+		core.just_sent_cards.clear();
 		raise_event((card*)0, EVENT_CHAIN_END, 0, 0, 0, 0, 0);
 		process_instant_event();
 		adjust_all();
@@ -4945,6 +4946,7 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 	return TRUE;
 }
 int32 field::break_effect() {
+	core.just_sent_cards.clear();
 	core.hint_timing[0] &= TIMING_DAMAGE_STEP | TIMING_DAMAGE_CAL;
 	core.hint_timing[1] &= TIMING_DAMAGE_STEP | TIMING_DAMAGE_CAL;
 	for (auto chit = core.new_ochain.begin(); chit != core.new_ochain.end();) {

--- a/processor.cpp
+++ b/processor.cpp
@@ -1890,7 +1890,7 @@ int32 field::process_instant_event() {
 			++eit;
 			card* phandler = peffect->get_handler();
 			if(!phandler->is_status(STATUS_EFFECT_ENABLED) || !peffect->is_condition_check(phandler->current.controler, ev) || 
-			   pduel->game_field->core.just_sent_cards.find(phandler) != pduel->game_field->core.just_sent_cards.end())
+			   (!(peffect->range & LOCATION_HAND) && core.just_sent_cards.find(phandler) != core.just_sent_cards.end()))
 				continue;
 			peffect->set_activate_location();
 			newchain.flag = 0;
@@ -1911,8 +1911,7 @@ int32 field::process_instant_event() {
 			++eit;
 			card* phandler = peffect->get_handler();
 			bool act = phandler->is_status(STATUS_EFFECT_ENABLED) && peffect->is_condition_check(phandler->current.controler, ev);
-			if((!act && !(peffect->range & LOCATION_HAND)) ||
-			   pduel->game_field->core.just_sent_cards.find(phandler) != pduel->game_field->core.just_sent_cards.end())
+			if(!(peffect->range & LOCATION_HAND) && (!act || core.just_sent_cards.find(phandler) != core.just_sent_cards.end()))
 				continue;
 			peffect->set_activate_location();
 			newchain.flag = 0;

--- a/processor.cpp
+++ b/processor.cpp
@@ -1889,7 +1889,8 @@ int32 field::process_instant_event() {
 			effect* peffect = eit->second;
 			++eit;
 			card* phandler = peffect->get_handler();
-			if(!phandler->is_status(STATUS_EFFECT_ENABLED) || !peffect->is_condition_check(phandler->current.controler, ev))
+			if(!phandler->is_status(STATUS_EFFECT_ENABLED) || !peffect->is_condition_check(phandler->current.controler, ev) || 
+			   pduel->game_field->core.just_sent_cards.find(phandler) != pduel->game_field->core.just_sent_cards.end())
 				continue;
 			peffect->set_activate_location();
 			newchain.flag = 0;
@@ -1910,7 +1911,8 @@ int32 field::process_instant_event() {
 			++eit;
 			card* phandler = peffect->get_handler();
 			bool act = phandler->is_status(STATUS_EFFECT_ENABLED) && peffect->is_condition_check(phandler->current.controler, ev);
-			if(!act && !(peffect->range & LOCATION_HAND))
+			if((!act && !(peffect->range & LOCATION_HAND)) ||
+			   pduel->game_field->core.just_sent_cards.find(phandler) != pduel->game_field->core.just_sent_cards.end())
 				continue;
 			peffect->set_activate_location();
 			newchain.flag = 0;
@@ -4474,7 +4476,7 @@ int32 field::add_chain(uint16 step) {
 		return FALSE;
 	}
 	case 7: {
-		break_effect();
+		break_effect(false);
 		auto& clit = core.current_chain.back();
 		effect* peffect = clit.triggering_effect;
 		card* phandler = peffect->get_handler();
@@ -4542,6 +4544,7 @@ int32 field::add_chain(uint16 step) {
 		message->write<uint8>(clit.chain_count);
 		raise_event(phandler, EVENT_CHAINING, peffect, 0, clit.triggering_player, clit.triggering_player, clit.chain_count);
 		process_instant_event();
+		core.just_sent_cards.clear();
 		if(core.new_chains.size())
 			add_process(PROCESSOR_ADD_CHAIN, 0, 0, 0, 0, 0);
 		adjust_all();
@@ -4945,8 +4948,9 @@ int32 field::solve_chain(uint16 step, uint32 chainend_arg1, uint32 chainend_arg2
 	}
 	return TRUE;
 }
-int32 field::break_effect() {
-	core.just_sent_cards.clear();
+int32 field::break_effect(bool clear_sent) {
+	if(clear_sent)
+		core.just_sent_cards.clear();
 	core.hint_timing[0] &= TIMING_DAMAGE_STEP | TIMING_DAMAGE_CAL;
 	core.hint_timing[1] &= TIMING_DAMAGE_STEP | TIMING_DAMAGE_CAL;
 	for (auto chit = core.new_ochain.begin(); chit != core.new_ochain.end();) {


### PR DESCRIPTION
This aims to be a proper solution for the workarounds used [here](https://github.com/Fluorohydride/ygopro-scripts/pull/1481) and [here](https://github.com/Fluorohydride/ygopro-scripts/pull/1486).
When a card is moved, it's put in the just_sent_cards set, if this happens during a chain, and in the activation validity check, it'll return false if the card is present in this set. This requires no script change, as it will all be handled internally.