### PR TITLE
Add new OCG_DuelOptions parameter to make the core not load "unsafe" libraries

### DIFF
--- a/duel.cpp
+++ b/duel.cpp
@@ -19,7 +19,7 @@ duel::duel(const OCG_DuelOptions& options) :
 	read_card_payload(options.payload1), read_script_payload(options.payload2),
 	handle_message_payload(options.payload3), read_card_done_payload(options.payload4)
 {
-	lua = new interpreter(this);
+	lua = new interpreter(this, options);
 	game_field = new field(this, options);
 	game_field->temp_card = new_card(0);
 }

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -16,7 +16,7 @@
 
 using namespace scriptlib;
 
-interpreter::interpreter(duel* pd): coroutines(256), deleted(pd) {
+interpreter::interpreter(duel* pd, const OCG_DuelOptions& options): coroutines(256), deleted(pd) {
 	lua_state = luaL_newstate();
 	current_state = lua_state;
 	pduel = pd;
@@ -32,7 +32,20 @@ interpreter::interpreter(duel* pd): coroutines(256), deleted(pd) {
 	open_lib(LUA_STRLIBNAME, luaopen_string);
 	open_lib(LUA_TABLIBNAME, luaopen_table);
 	open_lib(LUA_MATHLIBNAME, luaopen_math);
-	open_lib(LUA_IOLIBNAME, luaopen_io);
+	if(options.enableUnsafeLibraries != 0)
+		open_lib(LUA_IOLIBNAME, luaopen_io);
+	else {
+		// Remove "dangerous" functions
+		auto nil_out = [&](const char* name) 	{
+			lua_pushnil(lua_state);
+			lua_setglobal(lua_state, name);
+		};
+		nil_out("collectgarbage");
+		nil_out("dofile");
+		nil_out("load");
+		nil_out("loadfile");
+		nil_out("loadstring");
+	}
 	// Open all card scripting libs
 	scriptlib::push_card_lib(lua_state);
 	scriptlib::push_effect_lib(lua_state);

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -36,7 +36,7 @@ interpreter::interpreter(duel* pd, const OCG_DuelOptions& options): coroutines(2
 		open_lib(LUA_IOLIBNAME, luaopen_io);
 	else {
 		// Remove "dangerous" functions
-		auto nil_out = [&](const char* name) 	{
+		auto nil_out = [&](const char* name) {
 			lua_pushnil(lua_state);
 			lua_setglobal(lua_state, name);
 		};

--- a/interpreter.h
+++ b/interpreter.h
@@ -22,6 +22,7 @@
 #include <cstring>
 #include <cmath>
 #include "lua_obj.h"
+#include "ocgapi_types.h"
 
 class card;
 class effect;
@@ -45,7 +46,7 @@ public:
 	int32_t call_depth;
 	lua_invalid deleted;
 
-	explicit interpreter(duel* pd);
+	explicit interpreter(duel* pd, const OCG_DuelOptions& options);
 	~interpreter();
 
 	void register_card(card* pcard);

--- a/ocgapi_types.h
+++ b/ocgapi_types.h
@@ -67,6 +67,7 @@ typedef struct OCG_DuelOptions {
 	void* payload3; /* relayed to errorHandler */
 	OCG_DataReaderDone cardReaderDone;
 	void* payload4; /* relayed to cardReaderDone */
+	uint8_t enableUnsafeLibraries;
 }OCG_DuelOptions;
 
 typedef struct OCG_NewCardInfo {


### PR DESCRIPTION
ABI breaking follow up for https://github.com/edo9300/ygopro-core/pull/123