### PR TITLE
Add helper macros to ease declaration of lua functions

### DIFF
--- a/function_array_helper.h
+++ b/function_array_helper.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, Edoardo Lolletti <edoardo762@gmail.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+#ifndef FUNCTION_ARRAY_HELPER_H
+#define FUNCTION_ARRAY_HELPER_H
+
+#define MAKE_LUA_NAME_IMPL(module, name) c_lua_##module##_##name
+#define MAKE_LUA_NAME(module, name) MAKE_LUA_NAME_IMPL(module, name)
+
+#ifndef __INTELLISENSE__
+namespace {
+namespace Detail {
+template<std::size_t N>
+struct LuaFunction;
+
+template<std::size_t N, typename T, std::size_t... I>
+constexpr auto append(T t, std::index_sequence<I...>) {
+	return std::array<T, N + 1>{Detail::LuaFunction<I>::elem..., t};
+}
+
+template<std::size_t N, typename T>
+constexpr auto make_lua_functions_array(T t) {
+	return append<N>(t, std::make_index_sequence<N>());
+}
+} // namespace Detail
+} // namespace
+
+#define LUA_FUNCTION(name) \
+static int32_t MAKE_LUA_NAME(LUA_MODULE,name)(lua_State*); \
+template<> \
+struct Detail::LuaFunction<__COUNTER__> { \
+	static constexpr luaL_Reg elem{#name, MAKE_LUA_NAME(LUA_MODULE,name)}; \
+}; \
+static int32_t MAKE_LUA_NAME(LUA_MODULE,name)(lua_State* L)
+
+#define GET_LUA_FUNCTIONS_ARRAY() \
+	Detail::make_lua_functions_array<__COUNTER__>(luaL_Reg{nullptr, nullptr});
+
+
+#define LUA_FUNCTION_EXISTING(name,...) \
+template<> \
+struct Detail::LuaFunction<__COUNTER__> { \
+    static constexpr luaL_Reg elem{#name,__VA_ARGS__}; \
+}
+
+#define LUA_FUNCTION_ALIAS(name) LUA_DECLARE_ALIAS_INT(name, __COUNTER__)
+#define LUA_DECLARE_ALIAS_INT(name, __COUNTER__) \
+template<> \
+struct Detail::LuaFunction<__COUNTER__> { \
+    static constexpr luaL_Reg elem{#name,Detail::LuaFunction<__COUNTER__-1>::elem.func}; \
+}
+#else
+#define LUA_FUNCTION(name) \
+static int32_t MAKE_LUA_NAME(LUA_MODULE,name)(lua_State* L)
+#define LUA_FUNCTION_EXISTING(name,...) struct MAKE_LUA_NAME(LUA_MODULE,name) {}
+#define LUA_FUNCTION_ALIAS(name,...) struct MAKE_LUA_NAME(LUA_MODULE,name) {}
+#define GET_LUA_FUNCTIONS_ARRAY() std::array<luaL_Reg,1>{{{nullptr,nullptr}}};
+#endif // __INTELLISENSE__
+#endif // FUNCTION_ARRAY_HELPER_H

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -12,11 +12,14 @@
 #include "effect.h"
 #include "group.h"
 
+#define LUA_MODULE Card
+#include "function_array_helper.h"
+
 namespace {
 
 using namespace scriptlib;
 
-int32_t card_get_code(lua_State* L) {
+LUA_FUNCTION(GetCode) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -47,7 +50,7 @@ int32_t card_get_code(lua_State* L) {
 }
 // GetOriginalCode(): get the original code printed on card
 // return: 1 int
-int32_t card_get_origin_code(lua_State* L) {
+LUA_FUNCTION(GetOriginalCode) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(pcard->data.alias) {
@@ -62,7 +65,7 @@ int32_t card_get_origin_code(lua_State* L) {
 }
 // GetOriginalCodeRule(): get the original code in duel (can be different from printed code)
 // return: 1-2 int
-int32_t card_get_origin_code_rule(lua_State* L) {
+LUA_FUNCTION(GetOriginalCodeRule) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	effect_set eset;
@@ -79,7 +82,7 @@ int32_t card_get_origin_code_rule(lua_State* L) {
 	}
 	return 1;
 }
-int32_t card_get_set_card(lua_State* L) {
+LUA_FUNCTION(GetSetCard) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -107,7 +110,7 @@ int32_t card_get_set_card(lua_State* L) {
 	}
 	return count;
 }
-int32_t card_get_origin_set_card(lua_State* L) {
+LUA_FUNCTION(GetOriginalSetCard) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	uint32_t n = 0;
@@ -117,7 +120,7 @@ int32_t card_get_origin_set_card(lua_State* L) {
 	}
 	return n;
 }
-int32_t card_get_pre_set_card(lua_State* L) {
+LUA_FUNCTION(GetPreviousSetCard) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	int32_t count = pcard->get_pre_set_card();
@@ -127,7 +130,7 @@ int32_t card_get_pre_set_card(lua_State* L) {
 	}
 	return count;
 }
-int32_t card_get_type(lua_State* L) {
+LUA_FUNCTION(GetType) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -143,45 +146,45 @@ int32_t card_get_type(lua_State* L) {
 	lua_pushinteger(L, pcard->get_type(scard, sumtype, playerid));
 	return 1;
 }
-int32_t card_get_origin_type(lua_State* L) {
+LUA_FUNCTION(GetOriginalType) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->data.type);
 	return 1;
 }
-int32_t card_get_level(lua_State* L) {
+LUA_FUNCTION(GetLevel) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->get_level());
 	return 1;
 }
-int32_t card_get_rank(lua_State* L) {
+LUA_FUNCTION(GetRank) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->get_rank());
 	return 1;
 }
-int32_t card_get_link(lua_State* L) {
+LUA_FUNCTION(GetLink) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->get_link());
 	return 1;
 }
-int32_t card_get_synchro_level(lua_State* L) {
+LUA_FUNCTION(GetSynchroLevel) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto scard = lua_get<card*, true>(L, 2);
 	lua_pushinteger(L, pcard->get_synchro_level(scard));
 	return 1;
 }
-int32_t card_get_ritual_level(lua_State* L) {
+LUA_FUNCTION(GetRitualLevel) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto scard = lua_get<card*, true>(L, 2);
 	lua_pushinteger(L, pcard->get_ritual_level(scard));
 	return 1;
 }
-int32_t card_get_origin_level(lua_State* L) {
+LUA_FUNCTION(GetOriginalLevel) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if((pcard->data.type & (TYPE_XYZ | TYPE_LINK)) || (pcard->status & STATUS_NO_LEVEL))
@@ -190,7 +193,7 @@ int32_t card_get_origin_level(lua_State* L) {
 		lua_pushinteger(L, pcard->data.level);
 	return 1;
 }
-int32_t card_get_origin_rank(lua_State* L) {
+LUA_FUNCTION(GetOriginalRank) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(!(pcard->data.type & TYPE_XYZ))
@@ -199,7 +202,7 @@ int32_t card_get_origin_rank(lua_State* L) {
 		lua_pushinteger(L, pcard->data.level);
 	return 1;
 }
-int32_t card_is_xyz_level(lua_State* L) {
+LUA_FUNCTION(IsXyzLevel) {
 	check_param_count(L, 3);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto xyzcard = lua_get<card*, true>(L, 2);
@@ -207,44 +210,44 @@ int32_t card_is_xyz_level(lua_State* L) {
 	lua_pushboolean(L, pcard->check_xyz_level(xyzcard, lv));
 	return 1;
 }
-int32_t card_get_lscale(lua_State* L) {
+LUA_FUNCTION(GetLeftScale) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->get_lscale());
 	return 1;
 }
-int32_t card_get_origin_lscale(lua_State* L) {
+LUA_FUNCTION(GetOriginalLeftScale) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->data.lscale);
 	return 1;
 }
-int32_t card_get_rscale(lua_State* L) {
+LUA_FUNCTION(GetRightScale) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->get_rscale());
 	return 1;
 }
-int32_t card_get_origin_rscale(lua_State* L) {
+LUA_FUNCTION(GetOriginalRightScale) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->data.rscale);
 	return 1;
 }
-int32_t card_get_link_marker(lua_State* L) {
+LUA_FUNCTION(GetLinkMarker) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->get_link_marker());
 	return 1;
 }
-int32_t card_is_link_marker(lua_State* L) {
+LUA_FUNCTION(IsLinkMarker) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto dir = lua_get<uint32_t>(L, 2);
 	lua_pushboolean(L, pcard->is_link_marker(dir));
 	return 1;
 }
-int32_t card_get_linked_group(lua_State* L) {
+LUA_FUNCTION(GetLinkedGroup) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -254,7 +257,7 @@ int32_t card_get_linked_group(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t card_get_linked_group_count(lua_State* L) {
+LUA_FUNCTION(GetLinkedGroupCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	card_set cset;
@@ -262,7 +265,7 @@ int32_t card_get_linked_group_count(lua_State* L) {
 	lua_pushinteger(L, cset.size());
 	return 1;
 }
-int32_t card_get_linked_zone(lua_State* L) {
+LUA_FUNCTION(GetLinkedZone) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	uint32_t zone = pcard->get_linked_zone();
@@ -273,7 +276,7 @@ int32_t card_get_linked_zone(lua_State* L) {
 		lua_pushinteger(L, zone);
 	return 1;
 }
-int32_t card_get_free_linked_zone(lua_State* L) {
+LUA_FUNCTION(GetFreeLinkedZone) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	uint32_t zone = pcard->get_linked_zone(true);
@@ -284,7 +287,7 @@ int32_t card_get_free_linked_zone(lua_State* L) {
 		lua_pushinteger(L, zone);
 	return 1;
 }
-int32_t card_get_mutual_linked_group(lua_State* L) {
+LUA_FUNCTION(GetMutualLinkedGroup) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -294,7 +297,7 @@ int32_t card_get_mutual_linked_group(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t card_get_mutual_linked_group_count(lua_State* L) {
+LUA_FUNCTION(GetMutualLinkedGroupCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	card_set cset;
@@ -302,7 +305,7 @@ int32_t card_get_mutual_linked_group_count(lua_State* L) {
 	lua_pushinteger(L, cset.size());
 	return 1;
 }
-int32_t card_get_mutual_linked_zone(lua_State* L) {
+LUA_FUNCTION(GetMutualLinkedZone) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	uint32_t zone = pcard->get_mutual_linked_zone();
@@ -313,19 +316,19 @@ int32_t card_get_mutual_linked_zone(lua_State* L) {
 		lua_pushinteger(L, zone);
 	return 1;
 }
-int32_t card_is_linked(lua_State* L) {
+LUA_FUNCTION(IsLinked) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_link_state());
 	return 1;
 }
-int32_t card_is_extra_linked(lua_State* L) {
+LUA_FUNCTION(IsExtraLinked) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_extra_link_state());
 	return 1;
 }
-int32_t card_get_column_group(lua_State* L) {
+LUA_FUNCTION(GetColumnGroup) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -337,7 +340,7 @@ int32_t card_get_column_group(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t card_get_column_group_count(lua_State* L) {
+LUA_FUNCTION(GetColumnGroupCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto left = lua_get<uint8_t, 0>(L, 2);
@@ -347,7 +350,7 @@ int32_t card_get_column_group_count(lua_State* L) {
 	lua_pushinteger(L, cset.size());
 	return 1;
 }
-int32_t card_get_column_zone(lua_State* L) {
+LUA_FUNCTION(GetColumnZone) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto loc = lua_get<uint16_t>(L, 2);
@@ -361,13 +364,13 @@ int32_t card_get_column_zone(lua_State* L) {
 		lua_pushinteger(L, zone);
 	return 1;
 }
-int32_t card_is_all_column(lua_State* L) {
+LUA_FUNCTION(IsAllColumn) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_all_column());
 	return 1;
 }
-int32_t card_get_attribute(lua_State* L) {
+LUA_FUNCTION(GetAttribute) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -383,7 +386,7 @@ int32_t card_get_attribute(lua_State* L) {
 	lua_pushinteger(L, pcard->get_attribute(scard, sumtype, playerid));
 	return 1;
 }
-int32_t card_get_origin_attribute(lua_State* L) {
+LUA_FUNCTION(GetOriginalAttribute) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(pcard->status & STATUS_NO_LEVEL)
@@ -392,7 +395,7 @@ int32_t card_get_origin_attribute(lua_State* L) {
 		lua_pushinteger(L, pcard->data.attribute);
 	return 1;
 }
-int32_t card_get_race(lua_State* L) {
+LUA_FUNCTION(GetRace) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -408,7 +411,7 @@ int32_t card_get_race(lua_State* L) {
 	lua_pushinteger(L, pcard->get_race(scard, sumtype, playerid));
 	return 1;
 }
-int32_t card_get_origin_race(lua_State* L) {
+LUA_FUNCTION(GetOriginalRace) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(pcard->status & STATUS_NO_LEVEL)
@@ -417,7 +420,7 @@ int32_t card_get_origin_race(lua_State* L) {
 		lua_pushinteger(L, pcard->data.race);
 	return 1;
 }
-int32_t card_get_attack(lua_State* L) {
+LUA_FUNCTION(GetAttack) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	int32_t atk = pcard->get_attack();
@@ -426,7 +429,7 @@ int32_t card_get_attack(lua_State* L) {
 	lua_pushinteger(L, atk);
 	return 1;
 }
-int32_t card_get_origin_attack(lua_State* L) {
+LUA_FUNCTION(GetBaseAttack) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	int32_t atk = pcard->get_base_attack();
@@ -435,7 +438,7 @@ int32_t card_get_origin_attack(lua_State* L) {
 	lua_pushinteger(L, atk);
 	return 1;
 }
-int32_t card_get_text_attack(lua_State* L) {
+LUA_FUNCTION(GetTextAttack) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(pcard->status & STATUS_NO_LEVEL)
@@ -444,7 +447,7 @@ int32_t card_get_text_attack(lua_State* L) {
 		lua_pushinteger(L, pcard->data.attack);
 	return 1;
 }
-int32_t card_get_defense(lua_State* L) {
+LUA_FUNCTION(GetDefense) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	int32_t def = pcard->get_defense();
@@ -453,7 +456,7 @@ int32_t card_get_defense(lua_State* L) {
 	lua_pushinteger(L, def);
 	return 1;
 }
-int32_t card_get_origin_defense(lua_State* L) {
+LUA_FUNCTION(GetBaseDefense) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	int32_t def = pcard->get_base_defense();
@@ -462,7 +465,7 @@ int32_t card_get_origin_defense(lua_State* L) {
 	lua_pushinteger(L, def);
 	return 1;
 }
-int32_t card_get_text_defense(lua_State* L) {
+LUA_FUNCTION(GetTextDefense) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(pcard->status & STATUS_NO_LEVEL)
@@ -471,7 +474,7 @@ int32_t card_get_text_defense(lua_State* L) {
 		lua_pushinteger(L, pcard->data.defense);
 	return 1;
 }
-int32_t card_get_previous_code_onfield(lua_State* L) {
+LUA_FUNCTION(GetPreviousCodeOnField) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->previous.code);
@@ -481,91 +484,91 @@ int32_t card_get_previous_code_onfield(lua_State* L) {
 	}
 	return 1;
 }
-int32_t card_get_previous_type_onfield(lua_State* L) {
+LUA_FUNCTION(GetPreviousTypeOnField) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->previous.type);
 	return 1;
 }
-int32_t card_get_previous_level_onfield(lua_State* L) {
+LUA_FUNCTION(GetPreviousLevelOnField) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->previous.level);
 	return 1;
 }
-int32_t card_get_previous_rank_onfield(lua_State* L) {
+LUA_FUNCTION(GetPreviousRankOnField) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->previous.rank);
 	return 1;
 }
-int32_t card_get_previous_attribute_onfield(lua_State* L) {
+LUA_FUNCTION(GetPreviousAttributeOnField) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->previous.attribute);
 	return 1;
 }
-int32_t card_get_previous_race_onfield(lua_State* L) {
+LUA_FUNCTION(GetPreviousRaceOnField) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->previous.race);
 	return 1;
 }
-int32_t card_get_previous_attack_onfield(lua_State* L) {
+LUA_FUNCTION(GetPreviousAttackOnField) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->previous.attack);
 	return 1;
 }
-int32_t card_get_previous_defense_onfield(lua_State* L) {
+LUA_FUNCTION(GetPreviousDefenseOnField) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->previous.defense);
 	return 1;
 }
-int32_t card_get_owner(lua_State* L) {
+LUA_FUNCTION(GetOwner) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->owner);
 	return 1;
 }
-int32_t card_get_controler(lua_State* L) {
+LUA_FUNCTION(GetControler) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->current.controler);
 	return 1;
 }
-int32_t card_get_previous_controler(lua_State* L) {
+LUA_FUNCTION(GetPreviousControler) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->previous.controler);
 	return 1;
 }
-int32_t card_get_reason(lua_State* L) {
+LUA_FUNCTION(GetReason) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->current.reason);
 	return 1;
 }
-int32_t card_get_reason_card(lua_State* L) {
+LUA_FUNCTION(GetReasonCard) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	interpreter::pushobject(L, pcard->current.reason_card);
 	return 1;
 }
-int32_t card_get_reason_player(lua_State* L) {
+LUA_FUNCTION(GetReasonPlayer) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->current.reason_player);
 	return 1;
 }
-int32_t card_get_reason_effect(lua_State* L) {
+LUA_FUNCTION(GetReasonEffect) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	interpreter::pushobject(L, pcard->current.reason_effect);
 	return 1;
 }
-int32_t card_set_reason(lua_State* L) {
+LUA_FUNCTION(SetReason) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto reason = lua_get<uint32_t>(L, 2);
@@ -575,14 +578,14 @@ int32_t card_set_reason(lua_State* L) {
 		pcard->current.reason = reason;
 	return 0;
 }
-int32_t card_set_reason_card(lua_State* L) {
+LUA_FUNCTION(SetReasonCard) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto rcard = lua_get<card*, true>(L, 2);
 	pcard->current.reason_card = rcard;
 	return 0;
 }
-int32_t card_set_reason_player(lua_State* L) {
+LUA_FUNCTION(SetReasonPlayer) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto rp = lua_get<uint8_t>(L, 2);
@@ -590,32 +593,32 @@ int32_t card_set_reason_player(lua_State* L) {
 		pcard->current.reason_player = rp;
 	return 0;
 }
-int32_t card_set_reason_effect(lua_State* L) {
+LUA_FUNCTION(SetReasonEffect) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto re = lua_get<effect*, true>(L, 2);
 	pcard->current.reason_effect = re;
 	return 0;
 }
-int32_t card_get_position(lua_State* L) {
+LUA_FUNCTION(GetPosition) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->current.position);
 	return 1;
 }
-int32_t card_get_previous_position(lua_State* L) {
+LUA_FUNCTION(GetPreviousPosition) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->previous.position);
 	return 1;
 }
-int32_t card_get_battle_position(lua_State* L) {
+LUA_FUNCTION(GetBattlePosition) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->temp.position);
 	return 1;
 }
-int32_t card_get_location(lua_State* L) {
+LUA_FUNCTION(GetLocation) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(pcard->get_status(STATUS_SUMMONING | STATUS_SUMMON_DISABLED | STATUS_ACTIVATE_DISABLED | STATUS_SPSUMMON_STEP))
@@ -624,79 +627,79 @@ int32_t card_get_location(lua_State* L) {
 		lua_pushinteger(L, pcard->current.location);
 	return 1;
 }
-int32_t card_get_previous_location(lua_State* L) {
+LUA_FUNCTION(GetPreviousLocation) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->previous.location);
 	return 1;
 }
-int32_t card_get_sequence(lua_State* L) {
+LUA_FUNCTION(GetSequence) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->current.sequence);
 	return 1;
 }
-int32_t card_get_previous_sequence(lua_State* L) {
+LUA_FUNCTION(GetPreviousSequence) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->previous.sequence);
 	return 1;
 }
-int32_t card_get_summon_type(lua_State* L) {
+LUA_FUNCTION(GetSummonType) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->summon_info & 0xff00ffff);
 	return 1;
 }
-int32_t card_get_summon_location(lua_State* L) {
+LUA_FUNCTION(GetSummonLocation) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, (pcard->summon_info >> 16) & 0xff);
 	return 1;
 }
-int32_t card_get_summon_player(lua_State* L) {
+LUA_FUNCTION(GetSummonPlayer) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->summon_player);
 	return 1;
 }
-int32_t card_get_destination(lua_State* L) {
+LUA_FUNCTION(GetDestination) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->sendto_param.location);
 	return 1;
 }
-int32_t card_get_leave_field_dest(lua_State* L) {
+LUA_FUNCTION(GetLeaveFieldDest) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->leave_field_redirect(REASON_EFFECT));
 	return 1;
 }
-int32_t card_get_turnid(lua_State* L) {
+LUA_FUNCTION(GetTurnID) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->turnid);
 	return 1;
 }
-int32_t card_get_fieldid(lua_State* L) {
+LUA_FUNCTION(GetFieldID) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->fieldid);
 	return 1;
 }
-int32_t card_get_fieldidr(lua_State* L) {
+LUA_FUNCTION(GetRealFieldID) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->fieldid_r);
 	return 1;
 }
-int32_t card_get_cardid(lua_State* L) {
+LUA_FUNCTION(GetCardID) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->cardid);
 	return 1;
 }
-int32_t card_is_origin_code_rule(lua_State* L) {
+LUA_FUNCTION(IsOriginalCodeRule) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	uint32_t code1 = 0;
@@ -724,7 +727,7 @@ int32_t card_is_origin_code_rule(lua_State* L) {
 	lua_pushboolean(L, FALSE);
 	return 1;
 }
-int32_t card_is_code(lua_State* L) {
+LUA_FUNCTION(IsCode) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	uint32_t code1 = pcard->get_code();
@@ -742,7 +745,7 @@ int32_t card_is_code(lua_State* L) {
 	lua_pushboolean(L, FALSE);
 	return 1;
 }
-int32_t card_is_summon_code(lua_State* L) {
+LUA_FUNCTION(IsSummonCode) {
 	check_param_count(L, 5);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -791,7 +794,7 @@ int32_t card_is_summon_code(lua_State* L) {
 	lua_pushboolean(L, FALSE);
 	return 1;
 }
-int32_t card_is_set_card(lua_State* L) {
+LUA_FUNCTION(IsSetCard) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	uint32_t set_code = lua_get<uint32_t>(L, 2);
@@ -807,21 +810,21 @@ int32_t card_is_set_card(lua_State* L) {
 		lua_pushboolean(L, pcard->is_set_card(set_code));
 	return 1;
 }
-int32_t card_is_origin_set_card(lua_State* L) {
+LUA_FUNCTION(IsOriginalSetCard) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	uint32_t set_code = lua_get<uint32_t>(L, 2);
 	lua_pushboolean(L, pcard->is_origin_set_card(set_code));
 	return 1;
 }
-int32_t card_is_pre_set_card(lua_State* L) {
+LUA_FUNCTION(IsPreviousSetCard) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	uint32_t set_code = lua_get<uint32_t>(L, 2);
 	lua_pushboolean(L, pcard->is_pre_set_card(set_code));
 	return 1;
 }
-int32_t card_is_type(lua_State* L) {
+LUA_FUNCTION(IsType) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -851,19 +854,19 @@ inline int32_t is_prop(lua_State* L, uint32_t val) {
 	lua_pushboolean(L, FALSE);
 	return 1;
 }
-int32_t card_is_level(lua_State* L) {
+LUA_FUNCTION(IsLevel) {
 	check_param_count(L, 2);
 	return is_prop(L, lua_get<card*, true>(L, 1)->get_level());
 }
-int32_t card_is_rank(lua_State* L) {
+LUA_FUNCTION(IsRank) {
 	check_param_count(L, 2);
 	return is_prop(L, lua_get<card*, true>(L, 1)->get_rank());
 }
-int32_t card_is_link(lua_State* L) {
+LUA_FUNCTION(IsLink) {
 	check_param_count(L, 2);
 	return is_prop(L, lua_get<card*, true>(L, 1)->get_link());
 }
-int32_t card_is_attack(lua_State* L) {
+LUA_FUNCTION(IsAttack) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(!(pcard->data.type & TYPE_MONSTER) && !(pcard->get_type() & TYPE_MONSTER) && !pcard->is_affected_by_effect(EFFECT_PRE_MONSTER))
@@ -872,7 +875,7 @@ int32_t card_is_attack(lua_State* L) {
 		is_prop(L, pcard->get_attack());
 	return 1;
 }
-int32_t card_is_defense(lua_State* L) {
+LUA_FUNCTION(IsDefense) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if((pcard->data.type & TYPE_LINK)
@@ -882,7 +885,7 @@ int32_t card_is_defense(lua_State* L) {
 		is_prop(L, pcard->get_defense());
 	return 1;
 }
-int32_t card_is_race(lua_State* L) {
+LUA_FUNCTION(IsRace) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -899,7 +902,7 @@ int32_t card_is_race(lua_State* L) {
 	lua_pushboolean(L, pcard->get_race(scard, sumtype, playerid) & trace);
 	return 1;
 }
-int32_t card_is_attribute(lua_State* L) {
+LUA_FUNCTION(IsAttribute) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -916,14 +919,14 @@ int32_t card_is_attribute(lua_State* L) {
 	lua_pushboolean(L, pcard->get_attribute(scard, sumtype, playerid) & tattrib);
 	return 1;
 }
-int32_t card_is_reason(lua_State* L) {
+LUA_FUNCTION(IsReason) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto treason = lua_get<uint32_t>(L, 2);
 	lua_pushboolean(L, pcard->current.reason & treason);
 	return 1;
 }
-int32_t card_is_summon_type(lua_State* L) {
+LUA_FUNCTION(IsSummonType) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	uint32_t count = lua_gettop(L) - 1;
@@ -940,14 +943,14 @@ int32_t card_is_summon_type(lua_State* L) {
 	lua_pushboolean(L, result);
 	return 1;
 }
-int32_t card_is_status(lua_State* L) {
+LUA_FUNCTION(IsStatus) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto tstatus = lua_get<uint32_t>(L, 2);
 	lua_pushboolean(L, pcard->status & tstatus);
 	return 1;
 }
-int32_t card_is_not_tuner(lua_State* L) {
+LUA_FUNCTION(IsNotTuner) {
 	check_param_count(L, 3);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto scard = lua_get<card*, true>(L, 2);
@@ -955,7 +958,7 @@ int32_t card_is_not_tuner(lua_State* L) {
 	lua_pushboolean(L, pcard->is_not_tuner(scard, playerid));
 	return 1;
 }
-int32_t card_set_status(lua_State* L) {
+LUA_FUNCTION(SetStatus) {
 	check_param_count(L, 3);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(pcard->status & STATUS_COPYING_EFFECT)
@@ -965,13 +968,13 @@ int32_t card_set_status(lua_State* L) {
 	pcard->set_status(tstatus, enable);
 	return 0;
 }
-int32_t card_is_gemini_state(lua_State* L) {
+LUA_FUNCTION(IsGeminiState) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, !!pcard->is_affected_by_effect(EFFECT_GEMINI_STATUS));
 	return 1;
 }
-int32_t card_enable_gemini_state(lua_State* L) {
+LUA_FUNCTION(EnableGeminiState) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -985,20 +988,20 @@ int32_t card_enable_gemini_state(lua_State* L) {
 	pcard->add_effect(deffect);
 	return 0;
 }
-int32_t card_set_turn_counter(lua_State* L) {
+LUA_FUNCTION(SetTurnCounter) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto ct = lua_get<uint16_t>(L, 2);
 	pcard->count_turn(ct);
 	return 0;
 }
-int32_t card_get_turn_counter(lua_State* L) {
+LUA_FUNCTION(GetTurnCounter) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->turn_counter);
 	return 1;
 }
-int32_t card_set_material(lua_State* L) {
+LUA_FUNCTION(SetMaterial) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(!lua_isnoneornil(L, 2)) {
@@ -1014,7 +1017,7 @@ int32_t card_set_material(lua_State* L) {
 		pcard->set_material(nullptr);
 	return 0;
 }
-int32_t card_get_material(lua_State* L) {
+LUA_FUNCTION(GetMaterial) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1022,13 +1025,13 @@ int32_t card_get_material(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t card_get_material_count(lua_State* L) {
+LUA_FUNCTION(GetMaterialCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->material_cards.size());
 	return 1;
 }
-int32_t card_get_equip_group(lua_State* L) {
+LUA_FUNCTION(GetEquipGroup) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1036,25 +1039,25 @@ int32_t card_get_equip_group(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t card_get_equip_count(lua_State* L) {
+LUA_FUNCTION(GetEquipCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->equiping_cards.size());
 	return 1;
 }
-int32_t card_get_equip_target(lua_State* L) {
+LUA_FUNCTION(GetEquipTarget) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	interpreter::pushobject(L, pcard->equiping_target);
 	return 1;
 }
-int32_t card_get_pre_equip_target(lua_State* L) {
+LUA_FUNCTION(GetPreviousEquipTarget) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	interpreter::pushobject(L, pcard->pre_equip_target);
 	return 1;
 }
-int32_t card_check_equip_target(lua_State* L) {
+LUA_FUNCTION(CheckEquipTarget) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto target = lua_get<card*, true>(L, 2);
@@ -1066,7 +1069,7 @@ int32_t card_check_equip_target(lua_State* L) {
 		lua_pushboolean(L, 0);
 	return 1;
 }
-int32_t card_check_union_target(lua_State* L) {
+LUA_FUNCTION(CheckUnionTarget) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto target = lua_get<card*, true>(L, 2);
@@ -1078,14 +1081,14 @@ int32_t card_check_union_target(lua_State* L) {
 		lua_pushboolean(L, 0);
 	return 1;
 }
-int32_t card_get_union_count(lua_State* L) {
+LUA_FUNCTION(GetUnionCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->get_union_count());
 	lua_pushinteger(L, pcard->get_old_union_count());
 	return 2;
 }
-int32_t card_get_overlay_group(lua_State* L) {
+LUA_FUNCTION(GetOverlayGroup) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1093,19 +1096,19 @@ int32_t card_get_overlay_group(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t card_get_overlay_count(lua_State* L) {
+LUA_FUNCTION(GetOverlayCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->xyz_materials.size());
 	return 1;
 }
-int32_t card_get_overlay_target(lua_State* L) {
+LUA_FUNCTION(GetOverlayTarget) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	interpreter::pushobject(L, pcard->overlay_target);
 	return 1;
 }
-int32_t card_check_remove_overlay_card(lua_State* L) {
+LUA_FUNCTION(CheckRemoveOverlayCard) {
 	check_param_count(L, 4);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1118,7 +1121,7 @@ int32_t card_check_remove_overlay_card(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->is_player_can_remove_overlay_card(playerid, pgroup, 0, 0, count, reason));
 	return 1;
 }
-int32_t card_remove_overlay_card(lua_State* L) {
+LUA_FUNCTION(RemoveOverlayCard) {
 	check_action_permission(L);
 	check_param_count(L, 5);
 	const auto pduel = lua_get<duel*>(L);
@@ -1136,7 +1139,7 @@ int32_t card_remove_overlay_card(lua_State* L) {
 		return 1;
 	});
 }
-int32_t card_get_attacked_group(lua_State* L) {
+LUA_FUNCTION(GetAttackedGroup) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1148,19 +1151,19 @@ int32_t card_get_attacked_group(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t card_get_attacked_group_count(lua_State* L) {
+LUA_FUNCTION(GetAttackedGroupCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->attacked_cards.size());
 	return 1;
 }
-int32_t card_get_attacked_count(lua_State* L) {
+LUA_FUNCTION(GetAttackedCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->attacked_count);
 	return 1;
 }
-int32_t card_get_battled_group(lua_State* L) {
+LUA_FUNCTION(GetBattledGroup) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1172,32 +1175,32 @@ int32_t card_get_battled_group(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t card_get_battled_group_count(lua_State* L) {
+LUA_FUNCTION(GetBattledGroupCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->battled_cards.size());
 	return 1;
 }
-int32_t card_get_attack_announced_count(lua_State* L) {
+LUA_FUNCTION(GetAttackAnnouncedCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->attack_announce_count);
 	return 1;
 }
-int32_t card_is_direct_attacked(lua_State* L) {
+LUA_FUNCTION(IsDirectAttacked) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->attacked_cards.findcard(0));
 	return 1;
 }
-int32_t card_set_card_target(lua_State* L) {
+LUA_FUNCTION(SetCardTarget) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto ocard = lua_get<card*, true>(L, 2);
 	pcard->add_card_target(ocard);
 	return 0;
 }
-int32_t card_get_card_target(lua_State* L) {
+LUA_FUNCTION(GetCardTarget) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1205,7 +1208,7 @@ int32_t card_get_card_target(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t card_get_first_card_target(lua_State* L) {
+LUA_FUNCTION(GetFirstCardTarget) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(pcard->effect_target_cards.size())
@@ -1213,27 +1216,27 @@ int32_t card_get_first_card_target(lua_State* L) {
 	else lua_pushnil(L);
 	return 1;
 }
-int32_t card_get_card_target_count(lua_State* L) {
+LUA_FUNCTION(GetCardTargetCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->effect_target_cards.size());
 	return 1;
 }
-int32_t card_is_has_card_target(lua_State* L) {
+LUA_FUNCTION(IsHasCardTarget) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto rcard = lua_get<card*, true>(L, 2);
 	lua_pushboolean(L, pcard->effect_target_cards.count(rcard));
 	return 1;
 }
-int32_t card_cancel_card_target(lua_State* L) {
+LUA_FUNCTION(CancelCardTarget) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto rcard = lua_get<card*, true>(L, 2);
 	pcard->cancel_card_target(rcard);
 	return 0;
 }
-int32_t card_get_owner_target(lua_State* L) {
+LUA_FUNCTION(GetOwnerTarget) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1241,13 +1244,13 @@ int32_t card_get_owner_target(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t card_get_owner_target_count(lua_State* L) {
+LUA_FUNCTION(GetOwnerTargetCount) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushinteger(L, pcard->effect_target_owner.size());
 	return 1;
 }
-int32_t card_get_activate_effect(lua_State* L) {
+LUA_FUNCTION(GetActivateEffect) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	int32_t count = 0;
@@ -1259,7 +1262,7 @@ int32_t card_get_activate_effect(lua_State* L) {
 	}
 	return count;
 }
-int32_t card_check_activate_effect(lua_State* L) {
+LUA_FUNCTION(CheckActivateEffect) {
 	check_param_count(L, 4);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1288,7 +1291,7 @@ int32_t card_check_activate_effect(lua_State* L) {
 	}
 	return 0;
 }
-int32_t card_register_effect(lua_State* L) {
+LUA_FUNCTION(RegisterEffect) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1306,7 +1309,7 @@ int32_t card_register_effect(lua_State* L) {
 	lua_pushinteger(L, id);
 	return 1;
 }
-int32_t card_is_has_effect(lua_State* L) {
+LUA_FUNCTION(IsHasEffect) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto code = lua_get<uint32_t>(L, 2);
@@ -1334,7 +1337,7 @@ int32_t card_is_has_effect(lua_State* L) {
 	}
 	return size;
 }
-int32_t card_get_card_effect(lua_State* L) {
+LUA_FUNCTION(GetCardEffect) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto code = lua_get<uint32_t, 0>(L, 2);
@@ -1345,7 +1348,7 @@ int32_t card_get_card_effect(lua_State* L) {
 	}
 	return count;
 }
-int32_t card_reset_effect(lua_State* L) {
+LUA_FUNCTION(ResetEffect) {
 	check_param_count(L, 3);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto code = lua_get<uint32_t>(L, 2);
@@ -1353,7 +1356,7 @@ int32_t card_reset_effect(lua_State* L) {
 	pcard->reset(code, type);
 	return 0;
 }
-int32_t card_get_effect_count(lua_State* L) {
+LUA_FUNCTION(GetEffectCount) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto code = lua_get<uint32_t>(L, 2);
@@ -1362,7 +1365,7 @@ int32_t card_get_effect_count(lua_State* L) {
 	lua_pushinteger(L, eset.size());
 	return 1;
 }
-int32_t card_register_flag_effect(lua_State* L) {
+LUA_FUNCTION(RegisterFlagEffect) {
 	check_param_count(L, 5);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1390,21 +1393,21 @@ int32_t card_register_flag_effect(lua_State* L) {
 	interpreter::pushobject(L, peffect);
 	return 1;
 }
-int32_t card_get_flag_effect(lua_State* L) {
+LUA_FUNCTION(GetFlagEffect) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto code = (lua_get<uint32_t>(L, 2) & 0xfffffff) | 0x10000000;
 	lua_pushinteger(L, pcard->single_effect.count(code));
 	return 1;
 }
-int32_t card_reset_flag_effect(lua_State* L) {
+LUA_FUNCTION(ResetFlagEffect) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto code = (lua_get<uint32_t>(L, 2) & 0xfffffff) | 0x10000000;
 	pcard->reset(code, RESET_CODE);
 	return 0;
 }
-int32_t card_set_flag_effect_label(lua_State* L) {
+LUA_FUNCTION(SetFlagEffectLabel) {
 	check_param_count(L, 3);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto code = (lua_get<uint32_t>(L, 2) & 0xfffffff) | 0x10000000;
@@ -1418,7 +1421,7 @@ int32_t card_set_flag_effect_label(lua_State* L) {
 	}
 	return 1;
 }
-int32_t card_get_flag_effect_label(lua_State* L) {
+LUA_FUNCTION(GetFlagEffectLabel) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto code = (lua_get<uint32_t>(L, 2) & 0xfffffff) | 0x10000000;
@@ -1432,7 +1435,7 @@ int32_t card_get_flag_effect_label(lua_State* L) {
 	}
 	return count;
 }
-int32_t card_create_relation(lua_State* L) {
+LUA_FUNCTION(CreateRelation) {
 	check_param_count(L, 3);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto rcard = lua_get<card*, true>(L, 2);
@@ -1440,41 +1443,41 @@ int32_t card_create_relation(lua_State* L) {
 	pcard->create_relation(rcard, reset);
 	return 0;
 }
-int32_t card_release_relation(lua_State* L) {
+LUA_FUNCTION(ReleaseRelation) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto rcard = lua_get<card*, true>(L, 2);
 	pcard->release_relation(rcard);
 	return 0;
 }
-int32_t card_create_effect_relation(lua_State* L) {
+LUA_FUNCTION(CreateEffectRelation) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 2);
 	pcard->create_relation(peffect);
 	return 0;
 }
-int32_t card_release_effect_relation(lua_State* L) {
+LUA_FUNCTION(ReleaseEffectRelation) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 2);
 	pcard->release_relation(peffect);
 	return 0;
 }
-int32_t card_clear_effect_relation(lua_State* L) {
+LUA_FUNCTION(ClearEffectRelation) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	pcard->clear_relate_effect();
 	return 0;
 }
-int32_t card_is_relate_to_effect(lua_State* L) {
+LUA_FUNCTION(IsRelateToEffect) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 2);
 	lua_pushboolean(L, pcard->is_has_relation(peffect));
 	return 1;
 }
-int32_t card_is_relate_to_chain(lua_State* L) {
+LUA_FUNCTION(IsRelateToChain) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1484,21 +1487,21 @@ int32_t card_is_relate_to_chain(lua_State* L) {
 	lua_pushboolean(L, pcard->is_has_relation(pduel->game_field->core.current_chain[chain_count - 1]));
 	return 1;
 }
-int32_t card_is_relate_to_card(lua_State* L) {
+LUA_FUNCTION(IsRelateToCard) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto rcard = lua_get<card*, true>(L, 2);
 	lua_pushboolean(L, pcard->is_has_relation(rcard));
 	return 1;
 }
-int32_t card_is_relate_to_battle(lua_State* L) {
+LUA_FUNCTION(IsRelateToBattle) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->fieldid_r == pduel->game_field->core.pre_field[0] || pcard->fieldid_r == pduel->game_field->core.pre_field[1]);
 	return 1;
 }
-int32_t card_copy_effect(lua_State* L) {
+LUA_FUNCTION(CopyEffect) {
 	check_param_count(L, 3);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto code = lua_get<uint32_t>(L, 2);
@@ -1511,7 +1514,7 @@ int32_t card_copy_effect(lua_State* L) {
 	lua_pushinteger(L, pcard->copy_effect(code, reset, count));
 	return 1;
 }
-int32_t card_replace_effect(lua_State* L) {
+LUA_FUNCTION(ReplaceEffect) {
 	check_param_count(L, 3);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto code = lua_get<uint32_t>(L, 2);
@@ -1524,7 +1527,7 @@ int32_t card_replace_effect(lua_State* L) {
 	lua_pushinteger(L, pcard->replace_effect(code, reset, count));
 	return 1;
 }
-int32_t card_enable_unsummonable(lua_State* L) {
+LUA_FUNCTION(EnableUnsummonable) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1538,7 +1541,7 @@ int32_t card_enable_unsummonable(lua_State* L) {
 	}
 	return 0;
 }
-int32_t card_enable_revive_limit(lua_State* L) {
+LUA_FUNCTION(EnableReviveLimit) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1558,19 +1561,19 @@ int32_t card_enable_revive_limit(lua_State* L) {
 	}
 	return 0;
 }
-int32_t card_complete_procedure(lua_State* L) {
+LUA_FUNCTION(CompleteProcedure) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	pcard->set_status(STATUS_PROC_COMPLETE, TRUE);
 	return 0;
 }
-int32_t card_is_disabled(lua_State* L) {
+LUA_FUNCTION(IsDisabled) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_status(STATUS_DISABLED));
 	return 1;
 }
-int32_t card_is_destructable(lua_State* L) {
+LUA_FUNCTION(IsDestructable) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1583,46 +1586,25 @@ int32_t card_is_destructable(lua_State* L) {
 		lua_pushboolean(L, pcard->is_destructable());
 	return 1;
 }
-int32_t card_is_summonable(lua_State* L) {
+LUA_FUNCTION(IsSummonableCard) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_summonable_card());
 	return 1;
 }
-int32_t card_is_fusion_summonable_card(lua_State* L) {
-	check_param_count(L, 1);
-	auto pcard = lua_get<card*, true>(L, 1);
-	auto summon_type = lua_get<uint32_t, 0>(L, 2);
-	lua_pushboolean(L, pcard->is_fusion_summonable_card(summon_type));
-	return 1;
-}
-int32_t card_is_msetable(lua_State* L) {
-	check_param_count(L, 3);
-	const auto pduel = lua_get<duel*>(L);
-	auto pcard = lua_get<card*, true>(L, 1);
-	bool ign = lua_get<bool>(L, 2);
-	effect* peffect = 0;
-	if(!lua_isnoneornil(L, 3))
-		peffect = lua_get<effect*, true>(L, 3);
-	auto minc = lua_get<uint16_t, 0>(L, 4);
-	auto zone = lua_get<uint32_t, 0xff>(L, 5);
-	lua_pushboolean(L, pcard->is_setable_mzone(pduel->game_field->core.reason_player, ign, peffect, minc, zone));
-	return 1;
-}
-int32_t card_is_ssetable(lua_State* L) {
-	check_param_count(L, 1);
-	const auto pduel = lua_get<duel*>(L);
-	auto pcard = lua_get<card*, true>(L, 1);
-	bool ign = lua_get<bool, false>(L, 2);
-	lua_pushboolean(L, pcard->is_setable_szone(pduel->game_field->core.reason_player, ign));
-	return 1;
-}
-int32_t card_is_special_summonable(lua_State* L) {
+LUA_FUNCTION(IsSpecialSummonable) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto sumtype = lua_get<uint32_t, 0>(L, 2);
 	lua_pushboolean(L, pcard->is_special_summonable(pduel->game_field->core.reason_player, sumtype));
+	return 1;
+}
+LUA_FUNCTION(IsFusionSummonableCard) {
+	check_param_count(L, 1);
+	auto pcard = lua_get<card*, true>(L, 1);
+	auto summon_type = lua_get<uint32_t, 0>(L, 2);
+	lua_pushboolean(L, pcard->is_fusion_summonable_card(summon_type));
 	return 1;
 }
 inline int32_t spsummonable_rule(lua_State* L, uint32_t cardtype, uint32_t sumtype, uint32_t offset) {
@@ -1656,22 +1638,22 @@ inline int32_t spsummonable_rule(lua_State* L, uint32_t cardtype, uint32_t sumty
 	core.forced_summon_maxc = 0;
 	return 1;
 }
-int32_t card_is_synchro_summonable(lua_State* L) {
+LUA_FUNCTION(IsSynchroSummonable) {
 	return spsummonable_rule(L, TYPE_SYNCHRO, SUMMON_TYPE_SYNCHRO, 0);
 }
-int32_t card_is_xyz_summonable(lua_State* L) {
+LUA_FUNCTION(IsXyzSummonable) {
 	return spsummonable_rule(L, TYPE_XYZ, SUMMON_TYPE_XYZ, 0);
 }
-int32_t card_is_link_summonable(lua_State* L) {
+LUA_FUNCTION(IsLinkSummonable) {
 	return spsummonable_rule(L, TYPE_LINK, SUMMON_TYPE_LINK, 0);
 }
-int32_t card_is_procedure_summonable(lua_State* L) {
+LUA_FUNCTION(IsProcedureSummonable) {
 	check_param_count(L, 3);
 	auto cardtype = lua_get<uint32_t, true>(L, 2);
 	auto sumtype = lua_get<uint32_t, true>(L, 3);
 	return spsummonable_rule(L, cardtype, sumtype, 2);
 }
-int32_t card_is_can_be_summoned(lua_State* L) {
+LUA_FUNCTION(IsSummonable) {
 	check_param_count(L, 3);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1684,7 +1666,28 @@ int32_t card_is_can_be_summoned(lua_State* L) {
 	lua_pushboolean(L, pcard->is_can_be_summoned(pduel->game_field->core.reason_player, ign, peffect, minc, zone));
 	return 1;
 }
-int32_t card_is_can_be_special_summoned(lua_State* L) {
+LUA_FUNCTION(IsMSetable) {
+	check_param_count(L, 3);
+	const auto pduel = lua_get<duel*>(L);
+	auto pcard = lua_get<card*, true>(L, 1);
+	bool ign = lua_get<bool>(L, 2);
+	effect* peffect = 0;
+	if(!lua_isnoneornil(L, 3))
+		peffect = lua_get<effect*, true>(L, 3);
+	auto minc = lua_get<uint16_t, 0>(L, 4);
+	auto zone = lua_get<uint32_t, 0xff>(L, 5);
+	lua_pushboolean(L, pcard->is_setable_mzone(pduel->game_field->core.reason_player, ign, peffect, minc, zone));
+	return 1;
+}
+LUA_FUNCTION(IsSSetable) {
+	check_param_count(L, 1);
+	const auto pduel = lua_get<duel*>(L);
+	auto pcard = lua_get<card*, true>(L, 1);
+	bool ign = lua_get<bool, false>(L, 2);
+	lua_pushboolean(L, pcard->is_setable_szone(pduel->game_field->core.reason_player, ign));
+	return 1;
+}
+LUA_FUNCTION(IsCanBeSpecialSummoned) {
 	check_param_count(L, 6);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 2);
@@ -1698,7 +1701,7 @@ int32_t card_is_can_be_special_summoned(lua_State* L) {
 	lua_pushboolean(L, pcard->is_can_be_special_summoned(peffect, sumtype, sumpos, sumplayer, toplayer, nocheck, nolimit, zone));
 	return 1;
 }
-int32_t card_is_able_to_hand(lua_State* L) {
+LUA_FUNCTION(IsAbleToHand) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1706,28 +1709,28 @@ int32_t card_is_able_to_hand(lua_State* L) {
 	lua_pushboolean(L, pcard->is_capable_send_to_hand(p));
 	return 1;
 }
-int32_t card_is_able_to_grave(lua_State* L) {
-	check_param_count(L, 1);
-	const auto pduel = lua_get<duel*>(L);
-	auto pcard = lua_get<card*, true>(L, 1);
-	lua_pushboolean(L, pcard->is_capable_send_to_grave(pduel->game_field->core.reason_player));
-	return 1;
-}
-int32_t card_is_able_to_deck(lua_State* L) {
+LUA_FUNCTION(IsAbleToDeck) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_capable_send_to_deck(pduel->game_field->core.reason_player));
 	return 1;
 }
-int32_t card_is_able_to_extra(lua_State* L) {
+LUA_FUNCTION(IsAbleToExtra) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_capable_send_to_extra(pduel->game_field->core.reason_player));
 	return 1;
 }
-int32_t card_is_able_to_remove(lua_State* L) {
+LUA_FUNCTION(IsAbleToGrave) {
+	check_param_count(L, 1);
+	const auto pduel = lua_get<duel*>(L);
+	auto pcard = lua_get<card*, true>(L, 1);
+	lua_pushboolean(L, pcard->is_capable_send_to_grave(pduel->game_field->core.reason_player));
+	return 1;
+}
+LUA_FUNCTION(IsAbleToRemove) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1737,35 +1740,28 @@ int32_t card_is_able_to_remove(lua_State* L) {
 	lua_pushboolean(L, pcard->is_removeable(p, pos, reason));
 	return 1;
 }
-int32_t card_is_able_to_hand_as_cost(lua_State* L) {
+LUA_FUNCTION(IsAbleToHandAsCost) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_capable_cost_to_hand(pduel->game_field->core.reason_player));
 	return 1;
 }
-int32_t card_is_able_to_grave_as_cost(lua_State* L) {
-	check_param_count(L, 1);
-	const auto pduel = lua_get<duel*>(L);
-	auto pcard = lua_get<card*, true>(L, 1);
-	lua_pushboolean(L, pcard->is_capable_cost_to_grave(pduel->game_field->core.reason_player));
-	return 1;
-}
-int32_t card_is_able_to_deck_as_cost(lua_State* L) {
+LUA_FUNCTION(IsAbleToDeckAsCost) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_capable_cost_to_deck(pduel->game_field->core.reason_player));
 	return 1;
 }
-int32_t card_is_able_to_extra_as_cost(lua_State* L) {
+LUA_FUNCTION(IsAbleToExtraAsCost) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_capable_cost_to_extra(pduel->game_field->core.reason_player));
 	return 1;
 }
-int32_t card_is_able_to_deck_or_extra_as_cost(lua_State* L) {
+LUA_FUNCTION(IsAbleToDeckOrExtraAsCost) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1773,7 +1769,14 @@ int32_t card_is_able_to_deck_or_extra_as_cost(lua_State* L) {
 	lua_pushboolean(L, pcard->is_extra_deck_monster() ? pcard->is_capable_cost_to_extra(p) : pcard->is_capable_cost_to_deck(p));
 	return 1;
 }
-int32_t card_is_able_to_remove_as_cost(lua_State* L) {
+LUA_FUNCTION(IsAbleToGraveAsCost) {
+	check_param_count(L, 1);
+	const auto pduel = lua_get<duel*>(L);
+	auto pcard = lua_get<card*, true>(L, 1);
+	lua_pushboolean(L, pcard->is_capable_cost_to_grave(pduel->game_field->core.reason_player));
+	return 1;
+}
+LUA_FUNCTION(IsAbleToRemoveAsCost) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1781,14 +1784,14 @@ int32_t card_is_able_to_remove_as_cost(lua_State* L) {
 	lua_pushboolean(L, pcard->is_removeable_as_cost(pduel->game_field->core.reason_player, pos));
 	return 1;
 }
-int32_t card_is_releasable(lua_State* L) {
+LUA_FUNCTION(IsReleasable) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_releasable_by_nonsummon(pduel->game_field->core.reason_player));
 	return 1;
 }
-int32_t card_is_releasable_by_effect(lua_State* L) {
+LUA_FUNCTION(IsReleasableByEffect) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1797,7 +1800,7 @@ int32_t card_is_releasable_by_effect(lua_State* L) {
 	lua_pushboolean(L, pcard->is_releasable_by_nonsummon(p) && pcard->is_releasable_by_effect(p, re));
 	return 1;
 }
-int32_t card_is_discardable(lua_State* L) {
+LUA_FUNCTION(IsDiscardable) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1811,13 +1814,13 @@ int32_t card_is_discardable(lua_State* L) {
 		lua_pushboolean(L, 0);
 	return 1;
 }
-int32_t card_can_attack(lua_State* L) {
+LUA_FUNCTION(CanAttack) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_capable_attack());
 	return 1;
 }
-int32_t card_can_chain_attack(lua_State* L) {
+LUA_FUNCTION(CanChainAttack) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1844,52 +1847,52 @@ int32_t card_can_chain_attack(lua_State* L) {
 		lua_pushboolean(L, 1);
 	return 1;
 }
-int32_t card_is_faceup(lua_State* L) {
+LUA_FUNCTION(IsFaceup) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_position(POS_FACEUP));
 	return 1;
 }
-int32_t card_is_attack_pos(lua_State* L) {
+LUA_FUNCTION(IsAttackPos) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_position(POS_ATTACK));
 	return 1;
 }
-int32_t card_is_facedown(lua_State* L) {
+LUA_FUNCTION(IsFacedown) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_position(POS_FACEDOWN));
 	return 1;
 }
-int32_t card_is_defense_pos(lua_State* L) {
+LUA_FUNCTION(IsDefensePos) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_position(POS_DEFENSE));
 	return 1;
 }
-int32_t card_is_position(lua_State* L) {
+LUA_FUNCTION(IsPosition) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto pos = lua_get<uint8_t>(L, 2);
 	lua_pushboolean(L, pcard->is_position(pos));
 	return 1;
 }
-int32_t card_is_pre_position(lua_State* L) {
+LUA_FUNCTION(IsPreviousPosition) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto pos = lua_get<uint8_t>(L, 2);
 	lua_pushboolean(L, pcard->previous.position & pos);
 	return 1;
 }
-int32_t card_is_controler(lua_State* L) {
+LUA_FUNCTION(IsControler) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto con = lua_get<uint8_t>(L, 2);
 	lua_pushboolean(L, pcard->current.controler == con);
 	return 1;
 }
-int32_t card_is_onfield(lua_State* L) {
+LUA_FUNCTION(IsOnField) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if((pcard->current.location & LOCATION_ONFIELD)
@@ -1899,7 +1902,7 @@ int32_t card_is_onfield(lua_State* L) {
 		lua_pushboolean(L, 0);
 	return 1;
 }
-int32_t card_is_location(lua_State* L) {
+LUA_FUNCTION(IsLocation) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto loc = lua_get<uint16_t>(L, 2);
@@ -1917,14 +1920,14 @@ int32_t card_is_location(lua_State* L) {
 		lua_pushboolean(L, pcard->current.location & loc);
 	return 1;
 }
-int32_t card_is_pre_location(lua_State* L) {
+LUA_FUNCTION(IsPreviousLocation) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto loc = lua_get<uint16_t>(L, 2);
 	lua_pushboolean(L, pcard->previous.is_location(loc));
 	return 1;
 }
-int32_t card_is_level_below(lua_State* L) {
+LUA_FUNCTION(IsLevelBelow) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto lvl = lua_get<uint32_t>(L, 2);
@@ -1932,7 +1935,7 @@ int32_t card_is_level_below(lua_State* L) {
 	lua_pushboolean(L, plvl > 0 && plvl <= lvl);
 	return 1;
 }
-int32_t card_is_level_above(lua_State* L) {
+LUA_FUNCTION(IsLevelAbove) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto lvl = lua_get<uint32_t>(L, 2);
@@ -1940,7 +1943,7 @@ int32_t card_is_level_above(lua_State* L) {
 	lua_pushboolean(L, plvl > 0 && plvl >= lvl);
 	return 1;
 }
-int32_t card_is_rank_below(lua_State* L) {
+LUA_FUNCTION(IsRankBelow) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto rnk = lua_get<uint32_t>(L, 2);
@@ -1948,7 +1951,7 @@ int32_t card_is_rank_below(lua_State* L) {
 	lua_pushboolean(L, prnk > 0 && prnk <= rnk);
 	return 1;
 }
-int32_t card_is_rank_above(lua_State* L) {
+LUA_FUNCTION(IsRankAbove) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto rnk = lua_get<uint32_t>(L, 2);
@@ -1956,7 +1959,7 @@ int32_t card_is_rank_above(lua_State* L) {
 	lua_pushboolean(L, prnk > 0 && prnk >= rnk);
 	return 1;
 }
-int32_t card_is_link_below(lua_State* L) {
+LUA_FUNCTION(IsLinkBelow) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto lnk = lua_get<uint32_t>(L, 2);
@@ -1964,7 +1967,7 @@ int32_t card_is_link_below(lua_State* L) {
 	lua_pushboolean(L, plnk > 0 && plnk <= lnk);
 	return 1;
 }
-int32_t card_is_link_above(lua_State* L) {
+LUA_FUNCTION(IsLinkAbove) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto lnk = lua_get<uint32_t>(L, 2);
@@ -1972,7 +1975,7 @@ int32_t card_is_link_above(lua_State* L) {
 	lua_pushboolean(L, plnk > 0 && plnk >= lnk);
 	return 1;
 }
-int32_t card_is_attack_below(lua_State* L) {
+LUA_FUNCTION(IsAttackBelow) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto atk = lua_get<int32_t>(L, 2);
@@ -1984,7 +1987,7 @@ int32_t card_is_attack_below(lua_State* L) {
 	}
 	return 1;
 }
-int32_t card_is_attack_above(lua_State* L) {
+LUA_FUNCTION(IsAttackAbove) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto atk = lua_get<int32_t>(L, 2);
@@ -1995,7 +1998,7 @@ int32_t card_is_attack_above(lua_State* L) {
 	}
 	return 1;
 }
-int32_t card_is_defense_below(lua_State* L) {
+LUA_FUNCTION(IsDefenseBelow) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto def = lua_get<int32_t>(L, 2);
@@ -2008,7 +2011,7 @@ int32_t card_is_defense_below(lua_State* L) {
 	}
 	return 1;
 }
-int32_t card_is_defense_above(lua_State* L) {
+LUA_FUNCTION(IsDefenseAbove) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto def = lua_get<int32_t>(L, 2);
@@ -2020,25 +2023,25 @@ int32_t card_is_defense_above(lua_State* L) {
 	}
 	return 1;
 }
-int32_t card_is_public(lua_State* L) {
+LUA_FUNCTION(IsPublic) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_position(POS_FACEUP));
 	return 1;
 }
-int32_t card_is_forbidden(lua_State* L) {
+LUA_FUNCTION(IsForbidden) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_status(STATUS_FORBIDDEN));
 	return 1;
 }
-int32_t card_is_able_to_change_controler(lua_State* L) {
+LUA_FUNCTION(IsAbleToChangeControler) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_capable_change_control());
 	return 1;
 }
-int32_t card_is_controler_can_be_changed(lua_State* L) {
+LUA_FUNCTION(IsControlerCanBeChanged) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	bool ign = lua_get<bool, false>(L, 2);
@@ -2046,7 +2049,7 @@ int32_t card_is_controler_can_be_changed(lua_State* L) {
 	lua_pushboolean(L, pcard->is_control_can_be_changed(ign, zone));
 	return 1;
 }
-int32_t card_add_counter(lua_State* L) {
+LUA_FUNCTION(AddCounter) {
 	check_param_count(L, 3);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2059,7 +2062,7 @@ int32_t card_add_counter(lua_State* L) {
 		lua_pushboolean(L, 0);
 	return 1;
 }
-int32_t card_remove_counter(lua_State* L) {
+LUA_FUNCTION(RemoveCounter) {
 	check_action_permission(L);
 	check_param_count(L, 5);
 	const auto pduel = lua_get<duel*>(L);
@@ -2078,7 +2081,7 @@ int32_t card_remove_counter(lua_State* L) {
 		return 1;
 	});
 }
-int32_t card_remove_all_counters(lua_State* L) {
+LUA_FUNCTION(RemoveAllCounters) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -2097,7 +2100,7 @@ int32_t card_remove_all_counters(lua_State* L) {
 	lua_pushinteger(L, total);
 	return 1;
 }
-int32_t card_get_counter(lua_State* L) {
+LUA_FUNCTION(GetCounter) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto countertype = lua_get<uint16_t>(L, 2);
@@ -2108,7 +2111,7 @@ int32_t card_get_counter(lua_State* L) {
 	lua_pushinteger(L, pcard->get_counter(countertype));
 	return 1;
 }
-int32_t card_get_all_counters(lua_State* L) {
+LUA_FUNCTION(GetAllCounters) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_newtable(L);
@@ -2119,13 +2122,13 @@ int32_t card_get_all_counters(lua_State* L) {
 	}
 	return 1;
 }
-int32_t card_has_counters(lua_State* L) {
+LUA_FUNCTION(HasCounters) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->counters.size());
 	return 1;
 }
-int32_t card_enable_counter_permit(lua_State* L) {
+LUA_FUNCTION(EnableCounterPermit) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2147,7 +2150,7 @@ int32_t card_enable_counter_permit(lua_State* L) {
 	pcard->add_effect(peffect);
 	return 0;
 }
-int32_t card_set_counter_limit(lua_State* L) {
+LUA_FUNCTION(SetCounterLimit) {
 	check_param_count(L, 3);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2161,21 +2164,21 @@ int32_t card_set_counter_limit(lua_State* L) {
 	pcard->add_effect(peffect);
 	return 0;
 }
-int32_t card_is_can_change_position(lua_State* L) {
+LUA_FUNCTION(IsCanChangePosition) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_capable_change_position_by_effect(pduel->game_field->core.reason_player));
 	return 1;
 }
-int32_t card_is_can_turn_set(lua_State* L) {
+LUA_FUNCTION(IsCanTurnSet) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
 	lua_pushboolean(L, pcard->is_capable_turn_set(pduel->game_field->core.reason_player));
 	return 1;
 }
-int32_t card_is_can_add_counter(lua_State* L) {
+LUA_FUNCTION(IsCanAddCounter) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2186,7 +2189,7 @@ int32_t card_is_can_add_counter(lua_State* L) {
 	lua_pushboolean(L, pcard->is_can_add_counter(pduel->game_field->core.reason_player, countertype, count, singly, loc));
 	return 1;
 }
-int32_t card_is_can_remove_counter(lua_State* L) {
+LUA_FUNCTION(IsCanRemoveCounter) {
 	check_param_count(L, 5);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2199,7 +2202,7 @@ int32_t card_is_can_remove_counter(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->is_player_can_remove_counter(playerid, pcard, 0, 0, countertype, count, reason));
 	return 1;
 }
-int32_t card_is_can_be_fusion_material(lua_State* L) {
+LUA_FUNCTION(IsCanBeFusionMaterial) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2211,7 +2214,7 @@ int32_t card_is_can_be_fusion_material(lua_State* L) {
 	lua_pushboolean(L, pcard->is_can_be_fusion_material(fcard, summon_type, playerid));
 	return 1;
 }
-int32_t card_is_can_be_synchro_material(lua_State* L) {
+LUA_FUNCTION(IsCanBeSynchroMaterial) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	card* scard = 0;
@@ -2224,7 +2227,7 @@ int32_t card_is_can_be_synchro_material(lua_State* L) {
 	lua_pushboolean(L, pcard->is_can_be_synchro_material(scard, playerid, tuner));
 	return 1;
 }
-int32_t card_is_can_be_ritual_material(lua_State* L) {
+LUA_FUNCTION(IsCanBeRitualMaterial) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2235,7 +2238,7 @@ int32_t card_is_can_be_ritual_material(lua_State* L) {
 	lua_pushboolean(L, pcard->is_can_be_ritual_material(scard, playerid));
 	return 1;
 }
-int32_t card_is_can_be_xyz_material(lua_State* L) {
+LUA_FUNCTION(IsCanBeXyzMaterial) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	card* scard = nullptr;
@@ -2246,7 +2249,7 @@ int32_t card_is_can_be_xyz_material(lua_State* L) {
 	lua_pushboolean(L, pcard->is_can_be_xyz_material(scard, playerid, reason));
 	return 1;
 }
-int32_t card_is_can_be_link_material(lua_State* L) {
+LUA_FUNCTION(IsCanBeLinkMaterial) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	card* scard = 0;
@@ -2256,7 +2259,7 @@ int32_t card_is_can_be_link_material(lua_State* L) {
 	lua_pushboolean(L, pcard->is_can_be_link_material(scard, playerid));
 	return 1;
 }
-int32_t card_is_can_be_material(lua_State* L) {
+LUA_FUNCTION(IsCanBeMaterial) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	uint64_t sumtype = lua_get<uint64_t>(L, 2);
@@ -2267,7 +2270,7 @@ int32_t card_is_can_be_material(lua_State* L) {
 	lua_pushboolean(L, pcard->is_can_be_material(scard, sumtype, playerid));
 	return 1;
 }
-int32_t card_check_fusion_material(lua_State* L) {
+LUA_FUNCTION(CheckFusionMaterial) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2283,21 +2286,21 @@ int32_t card_check_fusion_material(lua_State* L) {
 	lua_pushboolean(L, pcard->fusion_check(pgroup, cg, chkf));
 	return 1;
 }
-int32_t card_check_fusion_substitute(lua_State* L) {
+LUA_FUNCTION(CheckFusionSubstitute) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto fcard = lua_get<card*, true>(L, 2);
 	lua_pushboolean(L, pcard->check_fusion_substitute(fcard));
 	return 1;
 }
-int32_t card_is_immune_to_effect(lua_State* L) {
+LUA_FUNCTION(IsImmuneToEffect) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 2);
 	lua_pushboolean(L, !pcard->is_affect_by_effect(peffect));
 	return 1;
 }
-int32_t card_is_can_be_effect_target(lua_State* L) {
+LUA_FUNCTION(IsCanBeEffectTarget) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2307,14 +2310,14 @@ int32_t card_is_can_be_effect_target(lua_State* L) {
 	lua_pushboolean(L, pcard->is_capable_be_effect_target(peffect, pduel->game_field->core.reason_player));
 	return 1;
 }
-int32_t card_is_can_be_battle_target(lua_State* L) {
+LUA_FUNCTION(IsCanBeBattleTarget) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto bcard = lua_get<card*, true>(L, 2);
 	lua_pushboolean(L, pcard->is_capable_be_battle_target(bcard));
 	return 1;
 }
-int32_t card_add_monster_attribute(lua_State* L) {
+LUA_FUNCTION(AddMonsterAttribute) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2391,10 +2394,11 @@ int32_t card_add_monster_attribute(lua_State* L) {
 	}
 	return 0;
 }
-int32_t card_add_monster_attribute_complete(lua_State* /*L*/) {
+LUA_FUNCTION(AddMonsterAttributeComplete) {
+	(void)L;
 	return 0;
 }
-int32_t card_cancel_to_grave(lua_State* L) {
+LUA_FUNCTION(CancelToGrave) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2407,7 +2411,7 @@ int32_t card_cancel_to_grave(lua_State* L) {
 	}
 	return 0;
 }
-int32_t card_get_tribute_requirement(lua_State* L) {
+LUA_FUNCTION(GetTributeRequirement) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	int32_t rcount = pcard->get_summon_tribute_count();
@@ -2415,7 +2419,7 @@ int32_t card_get_tribute_requirement(lua_State* L) {
 	lua_pushinteger(L, (rcount >> 16) & 0xffff);
 	return 2;
 }
-int32_t card_get_battle_target(lua_State* L) {
+LUA_FUNCTION(GetBattleTarget) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2426,7 +2430,7 @@ int32_t card_get_battle_target(lua_State* L) {
 	else lua_pushnil(L);
 	return 1;
 }
-int32_t card_get_attackable_target(lua_State* L) {
+LUA_FUNCTION(GetAttackableTarget) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2438,7 +2442,7 @@ int32_t card_get_attackable_target(lua_State* L) {
 	lua_pushboolean(L, (int32_t)pcard->direct_attackable);
 	return 2;
 }
-int32_t card_set_hint(lua_State* L) {
+LUA_FUNCTION(SetHint) {
 	check_param_count(L, 3);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2452,7 +2456,7 @@ int32_t card_set_hint(lua_State* L) {
 	message->write<uint64_t>(value);
 	return 0;
 }
-int32_t card_reverse_in_deck(lua_State* L) {
+LUA_FUNCTION(ReverseInDeck) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2468,7 +2472,7 @@ int32_t card_reverse_in_deck(lua_State* L) {
 	}
 	return 0;
 }
-int32_t card_set_unique_onfield(lua_State* L) {
+LUA_FUNCTION(SetUniqueOnField) {
 	check_param_count(L, 4);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2492,7 +2496,7 @@ int32_t card_set_unique_onfield(lua_State* L) {
 		pduel->game_field->add_unique_card(pcard);
 	return 0;
 }
-int32_t card_check_unique_onfield(lua_State* L) {
+LUA_FUNCTION(CheckUniqueOnField) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2502,7 +2506,7 @@ int32_t card_check_unique_onfield(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->check_unique_onfield(pcard, check_player, check_location, icard) ? 0 : 1);
 	return 1;
 }
-int32_t card_reset_negate_effect(lua_State* L) {
+LUA_FUNCTION(ResetNegateEffect) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	int32_t count = lua_gettop(L) - 1;
@@ -2510,7 +2514,7 @@ int32_t card_reset_negate_effect(lua_State* L) {
 		pcard->reset(lua_get<uint32_t>(L, i + 2), RESET_CARD);
 	return 0;
 }
-int32_t card_assume_prop(lua_State* L) {
+LUA_FUNCTION(AssumeProperty) {
 	check_param_count(L, 3);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2521,7 +2525,7 @@ int32_t card_assume_prop(lua_State* L) {
 	pduel->assumes.insert(pcard);
 	return 0;
 }
-int32_t card_set_spsummon_once(lua_State* L) {
+LUA_FUNCTION(SetSPSummonOnce) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -2531,37 +2535,29 @@ int32_t card_set_spsummon_once(lua_State* L) {
 	pduel->game_field->core.global_flag |= GLOBALFLAG_SPSUMMON_ONCE;
 	return 0;
 }
-#define CARD_INFO_FUNC(attr) int32_t card_##attr(lua_State* L) {\
+#define CARD_INFO_FUNC(lua_name,attr) \
+LUA_FUNCTION(lua_name) { \
 	check_param_count(L, 1);\
-	auto pcard = lua_get<card*, true>(L, 1);\
-	if(lua_gettop(L) > 1) {\
-		pcard->data.attr = lua_get<uint32_t>(L, 2);\
-		return 0;\
+	auto pcard = lua_get<card*, true>(L, 1); \
+	if(lua_gettop(L) > 1) { \
+		pcard->data.attr = lua_get<decltype(pcard->data.attr)>(L, 2); \
+		return 0; \
 	} else \
-		lua_pushinteger(L, pcard->data.attr);\
+		lua_pushinteger(L, pcard->data.attr); \
 	return 1;\
 }
-CARD_INFO_FUNC(code)
-CARD_INFO_FUNC(alias)
-CARD_INFO_FUNC(type)
-CARD_INFO_FUNC(level)
-CARD_INFO_FUNC(attribute)
-CARD_INFO_FUNC(race)
-CARD_INFO_FUNC(attack)
-CARD_INFO_FUNC(defense)
-CARD_INFO_FUNC(rscale)
-CARD_INFO_FUNC(lscale)
-CARD_INFO_FUNC(link_marker)
-#undef CARD_INFO_FUNC
-int32_t card_setcode(lua_State* L) { 
+CARD_INFO_FUNC(Code, code)
+CARD_INFO_FUNC(Alias, alias)
+
+LUA_FUNCTION(Setcode) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(lua_gettop(L) > 1) {
 		pcard->data.setcodes.clear();
 		if(lua_istable(L, 2)) {
-			lua_table_iterate(L, 2, [&setcodes = pcard->data.setcodes, &L] {
+			lua_table_iterate(L, 2, [&setcodes = pcard->data.setcodes, &L]{
 				setcodes.insert(lua_get<uint16_t>(L, -1));
-			});
+							  });
 		} else
 			pcard->data.setcodes.insert(lua_get<uint16_t>(L, 2));
 		return 0;
@@ -2571,7 +2567,18 @@ int32_t card_setcode(lua_State* L) {
 	}
 	return pcard->data.setcodes.size();
 }
-int32_t card_recreate(lua_State* L) {
+
+CARD_INFO_FUNC(Type, type)
+CARD_INFO_FUNC(Level, level)
+CARD_INFO_FUNC(Attribute, attribute)
+CARD_INFO_FUNC(Race, race)
+CARD_INFO_FUNC(Attack, attack)
+CARD_INFO_FUNC(Defense, defense)
+CARD_INFO_FUNC(Rscale, rscale)
+CARD_INFO_FUNC(Lscale, lscale)
+CARD_INFO_FUNC(LinkMarker, link_marker)
+#undef CARD_INFO_FUNC
+LUA_FUNCTION(Recreate) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto code = lua_get<uint32_t>(L, 2);
@@ -2599,7 +2606,7 @@ int32_t card_recreate(lua_State* L) {
 	}
 	return 0;
 }
-int32_t card_cover(lua_State* L) {
+LUA_FUNCTION(Cover) {
 	check_param_count(L, 1);
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(lua_gettop(L) > 1) {
@@ -2609,279 +2616,15 @@ int32_t card_cover(lua_State* L) {
 		lua_pushinteger(L, pcard->cover);
 	return 1;
 }
-
-static constexpr luaL_Reg cardlib[] = {
-	{ "GetCode", card_get_code },
-	{ "GetOriginalCode", card_get_origin_code },
-	{ "GetOriginalCodeRule", card_get_origin_code_rule },
-	{ "GetSetCard", card_get_set_card },
-	{ "GetOriginalSetCard", card_get_origin_set_card },
-	{ "GetPreviousSetCard", card_get_pre_set_card },
-	{ "GetType", card_get_type },
-	{ "GetOriginalType", card_get_origin_type },
-	{ "GetLevel", card_get_level },
-	{ "GetRank", card_get_rank },
-	{ "GetLink", card_get_link },
-	{ "GetSynchroLevel", card_get_synchro_level },
-	{ "GetRitualLevel", card_get_ritual_level },
-	{ "GetOriginalLevel", card_get_origin_level },
-	{ "GetOriginalRank", card_get_origin_rank },
-	{ "IsXyzLevel", card_is_xyz_level },
-	{ "GetLeftScale", card_get_lscale },
-	{ "GetOriginalLeftScale", card_get_origin_lscale },
-	{ "GetRightScale", card_get_rscale },
-	{ "GetOriginalRightScale", card_get_origin_rscale },
-	{ "GetLinkMarker", card_get_link_marker },
-	{ "IsLinkMarker", card_is_link_marker },
-	{ "GetLinkedGroup", card_get_linked_group },
-	{ "GetLinkedGroupCount", card_get_linked_group_count },
-	{ "GetLinkedZone", card_get_linked_zone },
-	{ "GetFreeLinkedZone", card_get_free_linked_zone },
-	{ "GetMutualLinkedGroup", card_get_mutual_linked_group },
-	{ "GetMutualLinkedGroupCount", card_get_mutual_linked_group_count },
-	{ "GetMutualLinkedZone", card_get_mutual_linked_zone },
-	{ "IsLinked", card_is_linked },
-	{ "IsExtraLinked", card_is_extra_linked },
-	{ "GetColumnGroup", card_get_column_group },
-	{ "GetColumnGroupCount", card_get_column_group_count },
-	{ "GetColumnZone", card_get_column_zone },
-	{ "IsAllColumn", card_is_all_column },
-	{ "GetAttribute", card_get_attribute },
-	{ "GetOriginalAttribute", card_get_origin_attribute },
-	{ "GetRace", card_get_race },
-	{ "GetOriginalRace", card_get_origin_race },
-	{ "GetAttack", card_get_attack },
-	{ "GetBaseAttack", card_get_origin_attack },
-	{ "GetTextAttack", card_get_text_attack },
-	{ "GetDefense",	card_get_defense },
-	{ "GetBaseDefense", card_get_origin_defense },
-	{ "GetTextDefense", card_get_text_defense },
-	{ "GetPreviousCodeOnField", card_get_previous_code_onfield },
-	{ "GetPreviousTypeOnField", card_get_previous_type_onfield },
-	{ "GetPreviousLevelOnField", card_get_previous_level_onfield },
-	{ "GetPreviousRankOnField", card_get_previous_rank_onfield },
-	{ "GetPreviousAttributeOnField", card_get_previous_attribute_onfield },
-	{ "GetPreviousRaceOnField", card_get_previous_race_onfield },
-	{ "GetPreviousAttackOnField", card_get_previous_attack_onfield },
-	{ "GetPreviousDefenseOnField", card_get_previous_defense_onfield },
-	{ "GetOwner", card_get_owner },
-	{ "GetControler", card_get_controler },
-	{ "GetPreviousControler", card_get_previous_controler },
-	{ "GetReason", card_get_reason },
-	{ "GetReasonCard", card_get_reason_card },
-	{ "GetReasonPlayer", card_get_reason_player },
-	{ "GetReasonEffect", card_get_reason_effect },
-	{ "SetReason", card_set_reason },
-	{ "SetReasonCard", card_set_reason_card },
-	{ "SetReasonPlayer", card_set_reason_player },
-	{ "SetReasonEffect", card_set_reason_effect },
-	{ "GetPosition", card_get_position },
-	{ "GetPreviousPosition", card_get_previous_position },
-	{ "GetBattlePosition", card_get_battle_position },
-	{ "GetLocation", card_get_location },
-	{ "GetPreviousLocation", card_get_previous_location },
-	{ "GetSequence", card_get_sequence },
-	{ "GetPreviousSequence", card_get_previous_sequence },
-	{ "GetSummonType", card_get_summon_type },
-	{ "GetSummonLocation", card_get_summon_location },
-	{ "GetSummonPlayer", card_get_summon_player },
-	{ "GetDestination", card_get_destination },
-	{ "GetLeaveFieldDest", card_get_leave_field_dest },
-	{ "GetTurnID", card_get_turnid },
-	{ "GetFieldID", card_get_fieldid },
-	{ "GetRealFieldID", card_get_fieldidr },
-	{ "GetCardID", card_get_cardid },
-	{ "IsOriginalCodeRule", card_is_origin_code_rule },
-	{ "IsCode", card_is_code },
-	{ "IsSummonCode", card_is_summon_code },
-	{ "IsSetCard", card_is_set_card },
-	{ "IsOriginalSetCard", card_is_origin_set_card },
-	{ "IsPreviousSetCard", card_is_pre_set_card },
-	{ "IsType", card_is_type },
-	{ "IsLevel", card_is_level },
-	{ "IsRank", card_is_rank },
-	{ "IsLink", card_is_link },
-	{ "IsAttack", card_is_attack },
-	{ "IsDefense", card_is_defense },
-	{ "IsRace", card_is_race },
-	{ "IsAttribute", card_is_attribute },
-	{ "IsReason", card_is_reason },
-	{ "IsSummonType", card_is_summon_type },
-	{ "IsStatus", card_is_status },
-	{ "IsNotTuner", card_is_not_tuner },
-	{ "SetStatus", card_set_status },
-	{ "IsGeminiState", card_is_gemini_state },
-	{ "EnableGeminiState", card_enable_gemini_state },
-	{ "SetTurnCounter",	card_set_turn_counter },
-	{ "GetTurnCounter", card_get_turn_counter },
-	{ "SetMaterial", card_set_material },
-	{ "GetMaterial", card_get_material },
-	{ "GetMaterialCount", card_get_material_count },
-	{ "GetEquipGroup", card_get_equip_group },
-	{ "GetEquipCount", card_get_equip_count },
-	{ "GetEquipTarget", card_get_equip_target },
-	{ "GetPreviousEquipTarget", card_get_pre_equip_target },
-	{ "CheckEquipTarget", card_check_equip_target },
-	{ "CheckUnionTarget", card_check_union_target },
-	{ "GetUnionCount", card_get_union_count },
-	{ "GetOverlayGroup", card_get_overlay_group },
-	{ "GetOverlayCount", card_get_overlay_count },
-	{ "GetOverlayTarget", card_get_overlay_target },
-	{ "CheckRemoveOverlayCard", card_check_remove_overlay_card },
-	{ "RemoveOverlayCard", card_remove_overlay_card },
-	{ "GetAttackedGroup", card_get_attacked_group },
-	{ "GetAttackedGroupCount", card_get_attacked_group_count },
-	{ "GetAttackedCount", card_get_attacked_count },
-	{ "GetBattledGroup", card_get_battled_group },
-	{ "GetBattledGroupCount", card_get_battled_group_count },
-	{ "GetAttackAnnouncedCount", card_get_attack_announced_count },
-	{ "IsDirectAttacked", card_is_direct_attacked },
-	{ "SetCardTarget", card_set_card_target },
-	{ "GetCardTarget", card_get_card_target },
-	{ "GetFirstCardTarget", card_get_first_card_target },
-	{ "GetCardTargetCount", card_get_card_target_count },
-	{ "IsHasCardTarget", card_is_has_card_target },
-	{ "CancelCardTarget", card_cancel_card_target },
-	{ "GetOwnerTarget", card_get_owner_target },
-	{ "GetOwnerTargetCount", card_get_owner_target_count },
-	{ "GetActivateEffect", card_get_activate_effect },
-	{ "CheckActivateEffect", card_check_activate_effect },
-	{ "RegisterEffect", card_register_effect },
-	{ "IsHasEffect", card_is_has_effect },
-	{ "GetCardEffect", card_get_card_effect },
-	{ "ResetEffect", card_reset_effect },
-	{ "GetEffectCount", card_get_effect_count },
-	{ "RegisterFlagEffect", card_register_flag_effect },
-	{ "GetFlagEffect", card_get_flag_effect },
-	{ "ResetFlagEffect", card_reset_flag_effect },
-	{ "SetFlagEffectLabel", card_set_flag_effect_label },
-	{ "GetFlagEffectLabel", card_get_flag_effect_label },
-	{ "CreateRelation", card_create_relation },
-	{ "ReleaseRelation", card_release_relation },
-	{ "CreateEffectRelation", card_create_effect_relation },
-	{ "ReleaseEffectRelation", card_release_effect_relation },
-	{ "ClearEffectRelation", card_clear_effect_relation },
-	{ "IsRelateToEffect", card_is_relate_to_effect },
-	{ "IsRelateToChain", card_is_relate_to_chain },
-	{ "IsRelateToCard", card_is_relate_to_card },
-	{ "IsRelateToBattle", card_is_relate_to_battle },
-	{ "CopyEffect", card_copy_effect },
-	{ "ReplaceEffect", card_replace_effect },
-	{ "EnableUnsummonable", card_enable_unsummonable },
-	{ "EnableReviveLimit", card_enable_revive_limit },
-	{ "CompleteProcedure", card_complete_procedure },
-	{ "IsDisabled", card_is_disabled },
-	{ "IsDestructable", card_is_destructable },
-	{ "IsSummonableCard", card_is_summonable },
-	{ "IsFusionSummonableCard", card_is_fusion_summonable_card },
-	{ "IsSpecialSummonable", card_is_special_summonable },
-	{ "IsSynchroSummonable", card_is_synchro_summonable },
-	{ "IsXyzSummonable", card_is_xyz_summonable },
-	{ "IsLinkSummonable", card_is_link_summonable },
-	{ "IsProcedureSummonable", card_is_procedure_summonable },
-	{ "IsSummonable", card_is_can_be_summoned },
-	{ "IsMSetable", card_is_msetable },
-	{ "IsSSetable", card_is_ssetable },
-	{ "IsCanBeSpecialSummoned", card_is_can_be_special_summoned },
-	{ "IsAbleToHand", card_is_able_to_hand },
-	{ "IsAbleToDeck", card_is_able_to_deck },
-	{ "IsAbleToExtra", card_is_able_to_extra },
-	{ "IsAbleToGrave", card_is_able_to_grave },
-	{ "IsAbleToRemove", card_is_able_to_remove },
-	{ "IsAbleToHandAsCost", card_is_able_to_hand_as_cost },
-	{ "IsAbleToDeckAsCost", card_is_able_to_deck_as_cost },
-	{ "IsAbleToExtraAsCost", card_is_able_to_extra_as_cost },
-	{ "IsAbleToDeckOrExtraAsCost", card_is_able_to_deck_or_extra_as_cost },
-	{ "IsAbleToGraveAsCost", card_is_able_to_grave_as_cost },
-	{ "IsAbleToRemoveAsCost", card_is_able_to_remove_as_cost },
-	{ "IsReleasable", card_is_releasable },
-	{ "IsReleasableByEffect", card_is_releasable_by_effect },
-	{ "IsDiscardable", card_is_discardable },
-	{ "CanAttack", card_can_attack },
-	{ "CanChainAttack", card_can_chain_attack },
-	{ "IsFaceup", card_is_faceup },
-	{ "IsAttackPos", card_is_attack_pos },
-	{ "IsFacedown", card_is_facedown },
-	{ "IsDefensePos", card_is_defense_pos },
-	{ "IsPosition", card_is_position },
-	{ "IsPreviousPosition", card_is_pre_position },
-	{ "IsControler", card_is_controler },
-	{ "IsOnField", card_is_onfield },
-	{ "IsLocation", card_is_location },
-	{ "IsPreviousLocation", card_is_pre_location },
-	{ "IsLevelBelow", card_is_level_below },
-	{ "IsLevelAbove", card_is_level_above },
-	{ "IsRankBelow", card_is_rank_below },
-	{ "IsRankAbove", card_is_rank_above },
-	{ "IsLinkBelow", card_is_link_below },
-	{ "IsLinkAbove", card_is_link_above },
-	{ "IsAttackBelow", card_is_attack_below },
-	{ "IsAttackAbove", card_is_attack_above },
-	{ "IsDefenseBelow", card_is_defense_below },
-	{ "IsDefenseAbove", card_is_defense_above },
-	{ "IsPublic", card_is_public },
-	{ "IsForbidden", card_is_forbidden },
-	{ "IsAbleToChangeControler", card_is_able_to_change_controler },
-	{ "IsControlerCanBeChanged", card_is_controler_can_be_changed },
-	{ "AddCounter", card_add_counter },
-	{ "RemoveCounter", card_remove_counter },
-	{ "RemoveAllCounters", card_remove_all_counters },
-	{ "GetCounter", card_get_counter },
-	{ "GetAllCounters", card_get_all_counters },
-	{ "HasCounters", card_has_counters },
-	{ "EnableCounterPermit", card_enable_counter_permit },
-	{ "SetCounterLimit", card_set_counter_limit },
-	{ "IsCanChangePosition", card_is_can_change_position },
-	{ "IsCanTurnSet", card_is_can_turn_set },
-	{ "IsCanAddCounter", card_is_can_add_counter },
-	{ "IsCanRemoveCounter", card_is_can_remove_counter },
-	{ "IsCanBeFusionMaterial", card_is_can_be_fusion_material },
-	{ "IsCanBeSynchroMaterial", card_is_can_be_synchro_material },
-	{ "IsCanBeRitualMaterial", card_is_can_be_ritual_material },
-	{ "IsCanBeXyzMaterial", card_is_can_be_xyz_material },
-	{ "IsCanBeLinkMaterial", card_is_can_be_link_material },
-	{ "IsCanBeMaterial", card_is_can_be_material },
-	{ "CheckFusionMaterial", card_check_fusion_material },
-	{ "CheckFusionSubstitute", card_check_fusion_substitute },
-	{ "IsImmuneToEffect", card_is_immune_to_effect },
-	{ "IsCanBeEffectTarget", card_is_can_be_effect_target },
-	{ "IsCanBeBattleTarget", card_is_can_be_battle_target },
-	{ "AddMonsterAttribute", card_add_monster_attribute },
-	{ "AddMonsterAttributeComplete", card_add_monster_attribute_complete },
-	{ "CancelToGrave", card_cancel_to_grave },
-	{ "GetTributeRequirement", card_get_tribute_requirement },
-	{ "GetBattleTarget", card_get_battle_target },
-	{ "GetAttackableTarget", card_get_attackable_target },
-	{ "SetHint", card_set_hint },
-	{ "ReverseInDeck", card_reverse_in_deck },
-	{ "SetUniqueOnField", card_set_unique_onfield },
-	{ "CheckUniqueOnField", card_check_unique_onfield },
-	{ "ResetNegateEffect", card_reset_negate_effect },
-	{ "AssumeProperty", card_assume_prop },
-	{ "SetSPSummonOnce", card_set_spsummon_once },
-	{ "Code", card_code },
-	{ "Alias", card_alias },
-	{ "Setcode", card_setcode },
-	{ "Type", card_type },
-	{ "Level", card_level },
-	{ "Attribute", card_attribute },
-	{ "Race", card_race },
-	{ "Attack", card_attack },
-	{ "Defense", card_defense },
-	{ "Rscale", card_rscale },
-	{ "Lscale", card_lscale },
-	{ "LinkMarker", card_link_marker },
-	{ "Recreate", card_recreate },
-	{ "Cover", card_cover },
-	{ "GetLuaRef", get_lua_ref<card> },
-	{ "FromLuaRef", from_lua_ref<card> },
-	{ "IsDeleted", is_deleted_object },
-	{ nullptr, nullptr }
-};
+LUA_FUNCTION_EXISTING(GetLuaRef, get_lua_ref<card>);
+LUA_FUNCTION_EXISTING(FromLuaRef, from_lua_ref<card>);
+LUA_FUNCTION_EXISTING(IsDeleted, is_deleted_object);
 }
 
 void scriptlib::push_card_lib(lua_State* L) {
-	luaL_newlib(L, cardlib);
+	static constexpr auto cardlib = GET_LUA_FUNCTIONS_ARRAY();
+	lua_createtable(L, 0, cardlib.size() - 1);
+	luaL_setfuncs(L, cardlib.data(), 0);
 	lua_pushstring(L, "__index");
 	lua_pushvalue(L, -2);
 	lua_rawset(L, -3);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -2623,6 +2623,7 @@ LUA_FUNCTION_EXISTING(IsDeleted, is_deleted_object);
 
 void scriptlib::push_card_lib(lua_State* L) {
 	static constexpr auto cardlib = GET_LUA_FUNCTIONS_ARRAY();
+	static_assert(cardlib.back().name == nullptr, "");
 	lua_createtable(L, 0, cardlib.size() - 1);
 	luaL_setfuncs(L, cardlib.data(), 0);
 	lua_pushstring(L, "__index");

--- a/libdebug.cpp
+++ b/libdebug.cpp
@@ -200,6 +200,7 @@ LUA_FUNCTION(PrintStacktrace) {
 
 void scriptlib::push_debug_lib(lua_State* L) {
 	static constexpr auto debuglib = GET_LUA_FUNCTIONS_ARRAY();
+	static_assert(debuglib.back().name == nullptr, "");
 	lua_createtable(L, 0, debuglib.size() - 1);
 	luaL_setfuncs(L, debuglib.data(), 0);
 	lua_setglobal(L, "Debug");

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -4319,6 +4319,7 @@ LUA_FUNCTION(GetStartingHand) {
 
 void scriptlib::push_duel_lib(lua_State* L) {
 	static constexpr auto duellib = GET_LUA_FUNCTIONS_ARRAY();
+	static_assert(duellib.back().name == nullptr, "");
 	lua_createtable(L, 0, duellib.size() - 1);
 	luaL_setfuncs(L, duellib.data(), 0);
 	lua_setglobal(L, "Duel");

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -13,18 +13,21 @@
 #include "effect.h"
 #include "group.h"
 
+#define LUA_MODULE Duel
+#include "function_array_helper.h"
+
 namespace {
 
 using namespace scriptlib;
 
-int32_t duel_enable_global_flag(lua_State* L) {
+LUA_FUNCTION(EnableGlobalFlag) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	pduel->game_field->core.global_flag |= lua_get<uint32_t>(L, 1);
 	return 0;
 }
 
-int32_t duel_get_lp(lua_State* L) {
+LUA_FUNCTION(GetLP) {
 	check_param_count(L, 1);
 	auto p = lua_get<int8_t>(L, 1);
 	if(p != 0 && p != 1)
@@ -33,7 +36,7 @@ int32_t duel_get_lp(lua_State* L) {
 	lua_pushinteger(L, pduel->game_field->player[p].lp);
 	return 1;
 }
-int32_t duel_set_lp(lua_State* L) {
+LUA_FUNCTION(SetLP) {
 	check_param_count(L, 2);
 	auto p = lua_get<int8_t>(L, 1);
 	auto lp = lua_get<int32_t>(L, 2);
@@ -47,12 +50,12 @@ int32_t duel_set_lp(lua_State* L) {
 	message->write<uint32_t>(lp);
 	return 0;
 }
-int32_t duel_get_turn_player(lua_State* L) {
+LUA_FUNCTION(GetTurnPlayer) {
 	const auto pduel = lua_get<duel*>(L);
 	lua_pushinteger(L, pduel->game_field->infos.turn_player);
 	return 1;
 }
-int32_t duel_get_turn_count(lua_State* L) {
+LUA_FUNCTION(GetTurnCount) {
 	const auto pduel = lua_get<duel*>(L);
 	if(lua_gettop(L) > 0) {
 		auto playerid = lua_get<uint8_t>(L, 1);
@@ -63,7 +66,7 @@ int32_t duel_get_turn_count(lua_State* L) {
 		lua_pushinteger(L, pduel->game_field->infos.turn_id);
 	return 1;
 }
-int32_t duel_get_draw_count(lua_State* L) {
+LUA_FUNCTION(GetDrawCount) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -72,7 +75,7 @@ int32_t duel_get_draw_count(lua_State* L) {
 	lua_pushinteger(L, pduel->game_field->get_draw_count(playerid));
 	return 1;
 }
-int32_t duel_register_effect(lua_State* L) {
+LUA_FUNCTION(RegisterEffect) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 2);
@@ -82,7 +85,7 @@ int32_t duel_register_effect(lua_State* L) {
 	pduel->game_field->add_effect(peffect, playerid);
 	return 0;
 }
-int32_t duel_register_flag_effect(lua_State* L) {
+LUA_FUNCTION(RegisterFlagEffect) {
 	check_param_count(L, 5);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -113,7 +116,7 @@ int32_t duel_register_flag_effect(lua_State* L) {
 	interpreter::pushobject(L, peffect);
 	return 1;
 }
-int32_t duel_get_flag_effect(lua_State* L) {
+LUA_FUNCTION(GetFlagEffect) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -125,7 +128,7 @@ int32_t duel_get_flag_effect(lua_State* L) {
 	lua_pushinteger(L, eset.size());
 	return 1;
 }
-int32_t duel_reset_flag_effect(lua_State* L) {
+LUA_FUNCTION(ResetFlagEffect) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -141,7 +144,7 @@ int32_t duel_reset_flag_effect(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_set_flag_effect_label(lua_State* L) {
+LUA_FUNCTION(SetFlagEffectLabel) {
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -160,7 +163,7 @@ int32_t duel_set_flag_effect_label(lua_State* L) {
 	}
 	return 1;
 }
-int32_t duel_get_flag_effect_label(lua_State* L) {
+LUA_FUNCTION(GetFlagEffectLabel) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -177,7 +180,7 @@ int32_t duel_get_flag_effect_label(lua_State* L) {
 		lua_pushinteger(L, eff->label.size() ? eff->label[0] : 0);
 	return eset.size();
 }
-int32_t duel_destroy(lua_State* L) {
+LUA_FUNCTION(Destroy) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	card* pcard = nullptr;
@@ -195,7 +198,7 @@ int32_t duel_destroy(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_remove(lua_State* L) {
+LUA_FUNCTION(Remove) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	card* pcard = nullptr;
@@ -214,7 +217,7 @@ int32_t duel_remove(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_sendto_grave(lua_State* L) {
+LUA_FUNCTION(SendtoGrave) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	card* pcard = nullptr;
@@ -232,7 +235,7 @@ int32_t duel_sendto_grave(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_summon(lua_State* L) {
+LUA_FUNCTION(Summon) {
 	check_action_permission(L);
 	check_param_count(L, 4);
 	const auto pduel = lua_get<duel*>(L);
@@ -255,7 +258,7 @@ int32_t duel_summon(lua_State* L) {
 	}
 	return lua_yield(L, 0);
 }
-int32_t duel_special_summon_rule(lua_State* L) {
+LUA_FUNCTION(SpecialSummonRule) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
@@ -316,16 +319,16 @@ inline int32_t spsummon_rule(lua_State* L, uint32_t summon_type, uint32_t offset
 	}
 	return lua_yield(L, 0);
 }
-int32_t duel_synchro_summon(lua_State* L) {
+LUA_FUNCTION(SynchroSummon) {
 	return spsummon_rule(L, SUMMON_TYPE_SYNCHRO, 0);
 }
-int32_t duel_xyz_summon(lua_State* L) {
+LUA_FUNCTION(XyzSummon) {
 	return spsummon_rule(L, SUMMON_TYPE_XYZ, 0);
 }
-int32_t duel_link_summon(lua_State* L) {
+LUA_FUNCTION(LinkSummon) {
 	return spsummon_rule(L, SUMMON_TYPE_LINK, 0);
 }
-int32_t duel_procedure_summon(lua_State* L) {
+LUA_FUNCTION(ProcedureSummon) {
 	check_param_count(L, 3);
 	auto sumtype = lua_get<uint32_t>(L, 3);
 	return spsummon_rule(L, sumtype, 1);
@@ -344,15 +347,15 @@ inline int32_t spsummon_rule_group(lua_State* L, uint32_t summon_type, uint32_t 
 	}
 	return lua_yield(L, 0);
 }
-int32_t duel_pendulum_summon(lua_State* L) {
+LUA_FUNCTION(PendulumSummon) {
 	return spsummon_rule_group(L, SUMMON_TYPE_PENDULUM, 0);
 }
-int32_t duel_procedure_summon_group(lua_State* L) {
+LUA_FUNCTION(ProcedureSummonGroup) {
 	check_param_count(L, 2);
 	auto sumtype = lua_get<uint32_t>(L, 2);
 	return spsummon_rule_group(L, sumtype, 1);
 }
-int32_t duel_setm(lua_State* L) {
+LUA_FUNCTION(MSet) {
 	check_action_permission(L);
 	check_param_count(L, 4);
 	const auto pduel = lua_get<duel*>(L);
@@ -375,7 +378,7 @@ int32_t duel_setm(lua_State* L) {
 	}
 	return lua_yield(L, 0);
 }
-int32_t duel_sets(lua_State* L) {
+LUA_FUNCTION(SSet) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -400,7 +403,7 @@ int32_t duel_sets(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_create_token(lua_State* L) {
+LUA_FUNCTION(CreateToken) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -417,7 +420,7 @@ int32_t duel_create_token(lua_State* L) {
 	interpreter::pushobject(L, pcard);
 	return 1;
 }
-int32_t duel_special_summon(lua_State* L) {
+LUA_FUNCTION(SpecialSummon) {
 	check_action_permission(L);
 	check_param_count(L, 7);
 	card* pcard = nullptr;
@@ -442,7 +445,7 @@ int32_t duel_special_summon(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_special_summon_step(lua_State* L) {
+LUA_FUNCTION(SpecialSummonStep) {
 	check_action_permission(L);
 	check_param_count(L, 7);
 	const auto pduel = lua_get<duel*>(L);
@@ -462,7 +465,7 @@ int32_t duel_special_summon_step(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_special_summon_complete(lua_State* L) {
+LUA_FUNCTION(SpecialSummonComplete) {
 	check_action_permission(L);
 	const auto pduel = lua_get<duel*>(L);
 	auto& core = pduel->game_field->core;
@@ -477,7 +480,7 @@ int32_t duel_special_summon_complete(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_sendto_hand(lua_State* L) {
+LUA_FUNCTION(SendtoHand) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	card* pcard = nullptr;
@@ -497,7 +500,7 @@ int32_t duel_sendto_hand(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_sendto_deck(lua_State* L) {
+LUA_FUNCTION(SendtoDeck) {
 	check_action_permission(L);
 	check_param_count(L, 4);
 	card* pcard = nullptr;
@@ -519,7 +522,7 @@ int32_t duel_sendto_deck(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_sendto_extra(lua_State* L) {
+LUA_FUNCTION(SendtoExtraP) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	card* pcard = nullptr;
@@ -539,7 +542,7 @@ int32_t duel_sendto_extra(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_sendto(lua_State* L) {
+LUA_FUNCTION(Sendto) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	card* pcard = nullptr;
@@ -562,7 +565,7 @@ int32_t duel_sendto(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_remove_cards(lua_State* L) {
+LUA_FUNCTION(RemoveCards) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	card* pcard = nullptr;
@@ -588,13 +591,13 @@ int32_t duel_remove_cards(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_get_operated_group(lua_State* L) {
+LUA_FUNCTION(GetOperatedGroup) {
 	const auto pduel = lua_get<duel*>(L);
 	group* pgroup = pduel->new_group(pduel->game_field->core.operated_set);
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t duel_is_can_add_counter(lua_State* L) {
+LUA_FUNCTION(IsCanAddCounter) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -613,7 +616,7 @@ int32_t duel_is_can_add_counter(lua_State* L) {
 	}
 	return 1;
 }
-int32_t duel_remove_counter(lua_State* L) {
+LUA_FUNCTION(RemoveCounter) {
 	check_action_permission(L);
 	check_param_count(L, 6);
 	auto rplayer = lua_get<uint8_t>(L, 1);
@@ -631,7 +634,7 @@ int32_t duel_remove_counter(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_is_can_remove_counter(lua_State* L) {
+LUA_FUNCTION(IsCanRemoveCounter) {
 	check_param_count(L, 6);
 	auto rplayer = lua_get<uint8_t>(L, 1);
 	if(rplayer != 0 && rplayer != 1)
@@ -645,7 +648,7 @@ int32_t duel_is_can_remove_counter(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->is_player_can_remove_counter(rplayer, 0, self, oppo, countertype, count, reason));
 	return 1;
 }
-int32_t duel_get_counter(lua_State* L) {
+LUA_FUNCTION(GetCounter) {
 	check_param_count(L, 4);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -657,7 +660,7 @@ int32_t duel_get_counter(lua_State* L) {
 	lua_pushinteger(L, pduel->game_field->get_field_counter(playerid, self, oppo, countertype));
 	return 1;
 }
-int32_t duel_change_form(lua_State* L) {
+LUA_FUNCTION(ChangePosition) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	card* pcard = nullptr;
@@ -679,7 +682,7 @@ int32_t duel_change_form(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_release(lua_State* L) {
+LUA_FUNCTION(Release) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	card* pcard = nullptr;
@@ -696,7 +699,7 @@ int32_t duel_release(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_move_to_field(lua_State* L) {
+LUA_FUNCTION(MoveToField) {
 	check_action_permission(L);
 	check_param_count(L, 6);
 	const auto pduel = lua_get<duel*>(L);
@@ -717,7 +720,7 @@ int32_t duel_move_to_field(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_return_to_field(lua_State* L) {
+LUA_FUNCTION(ReturnToField) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -735,7 +738,7 @@ int32_t duel_return_to_field(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_move_sequence(lua_State* L) {
+LUA_FUNCTION(MoveSequence) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
@@ -800,7 +803,7 @@ int32_t duel_move_sequence(lua_State* L) {
 	lua_pushboolean(L, res);
 	return 1;
 }
-int32_t duel_swap_sequence(lua_State* L) {
+LUA_FUNCTION(SwapSequence) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
@@ -822,7 +825,7 @@ int32_t duel_swap_sequence(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_activate_effect(lua_State* L) {
+LUA_FUNCTION(Activate) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -830,7 +833,7 @@ int32_t duel_activate_effect(lua_State* L) {
 	pduel->game_field->add_process(PROCESSOR_ACTIVATE_EFFECT, 0, peffect, 0, 0, 0);
 	return 0;
 }
-int32_t duel_set_chain_limit(lua_State* L) {
+LUA_FUNCTION(SetChainLimit) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_FUNCTION, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -838,7 +841,7 @@ int32_t duel_set_chain_limit(lua_State* L) {
 	pduel->game_field->core.chain_limit.emplace_back(f, pduel->game_field->core.reason_player);
 	return 0;
 }
-int32_t duel_set_chain_limit_p(lua_State* L) {
+LUA_FUNCTION(SetChainLimitTillChainEnd) {
 	check_param_count(L, 1);
 	check_param(L, PARAM_TYPE_FUNCTION, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -846,7 +849,7 @@ int32_t duel_set_chain_limit_p(lua_State* L) {
 	pduel->game_field->core.chain_limit_p.emplace_back(f, pduel->game_field->core.reason_player);
 	return 0;
 }
-int32_t duel_get_chain_material(lua_State* L) {
+LUA_FUNCTION(GetChainMaterial) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -859,7 +862,7 @@ int32_t duel_get_chain_material(lua_State* L) {
 	interpreter::pushobject(L, eset[0]);
 	return 1;
 }
-int32_t duel_confirm_decktop(lua_State* L) {
+LUA_FUNCTION(ConfirmDecktop) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -892,7 +895,7 @@ int32_t duel_confirm_decktop(lua_State* L) {
 	}
 	return lua_yield(L, 0);
 }
-int32_t duel_confirm_extratop(lua_State* L) {
+LUA_FUNCTION(ConfirmExtratop) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -915,7 +918,7 @@ int32_t duel_confirm_extratop(lua_State* L) {
 	}
 	return lua_yield(L, 0);
 }
-int32_t duel_confirm_cards(lua_State* L) {
+LUA_FUNCTION(ConfirmCards) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -945,7 +948,7 @@ int32_t duel_confirm_cards(lua_State* L) {
 	}
 	return lua_yield(L, 0);
 }
-int32_t duel_sort_decktop(lua_State* L) {
+LUA_FUNCTION(SortDecktop) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	auto sort_player = lua_get<uint8_t>(L, 1);
@@ -961,7 +964,7 @@ int32_t duel_sort_decktop(lua_State* L) {
 	pduel->game_field->add_process(PROCESSOR_SORT_DECK, 0, 0, 0, sort_player + (target_player << 16), count, FALSE);
 	return lua_yield(L, 0);
 }
-int32_t duel_sort_deckbottom(lua_State* L) {
+LUA_FUNCTION(SortDeckbottom) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	auto sort_player = lua_get<uint8_t>(L, 1);
@@ -977,7 +980,7 @@ int32_t duel_sort_deckbottom(lua_State* L) {
 	pduel->game_field->add_process(PROCESSOR_SORT_DECK, 0, 0, 0, sort_player + (target_player << 16), count, TRUE);
 	return lua_yield(L, 0);
 }
-int32_t duel_check_event(lua_State* L) {
+LUA_FUNCTION(CheckEvent) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto ev = lua_get<uint32_t>(L, 1);
@@ -1001,7 +1004,7 @@ int32_t duel_check_event(lua_State* L) {
 		}
 	}
 }
-int32_t duel_raise_event(lua_State* L) {
+LUA_FUNCTION(RaiseEvent) {
 	check_action_permission(L);
 	check_param_count(L, 7);
 	card* pcard = nullptr;
@@ -1023,7 +1026,7 @@ int32_t duel_raise_event(lua_State* L) {
 	pduel->game_field->process_instant_event();
 	return lua_yield(L, 0);
 }
-int32_t duel_raise_single_event(lua_State* L) {
+LUA_FUNCTION(RaiseSingleEvent) {
 	check_action_permission(L);
 	check_param_count(L, 7);
 	const auto pduel = lua_get<duel*>(L);
@@ -1038,14 +1041,14 @@ int32_t duel_raise_single_event(lua_State* L) {
 	pduel->game_field->process_single_event();
 	return lua_yield(L, 0);
 }
-int32_t duel_check_timing(lua_State* L) {
+LUA_FUNCTION(CheckTiming) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto tm = lua_get<uint32_t>(L, 1);
 	lua_pushboolean(L, (pduel->game_field->core.hint_timing[0]&tm) || (pduel->game_field->core.hint_timing[1]&tm));
 	return 1;
 }
-int32_t duel_get_environment(lua_State* L) {
+LUA_FUNCTION(GetEnvironment) {
 	const auto pduel = lua_get<duel*>(L);
 	uint32_t code = 0;
 	uint8_t p = 2;
@@ -1070,7 +1073,7 @@ int32_t duel_get_environment(lua_State* L) {
 	lua_pushinteger(L, p);
 	return 2;
 }
-int32_t duel_is_environment(lua_State* L) {
+LUA_FUNCTION(IsEnvironment) {
 	check_param_count(L, 1);
 	auto code = lua_get<uint32_t>(L, 1);
 	auto playerid = lua_get<uint8_t, PLAYER_ALL>(L, 2);
@@ -1136,7 +1139,7 @@ int32_t duel_is_environment(lua_State* L) {
 	lua_pushboolean(L, FALSE);
 	return 1;
 }
-int32_t duel_win(lua_State* L) {
+LUA_FUNCTION(Win) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto reason = lua_get<uint32_t>(L, 2);
@@ -1168,7 +1171,7 @@ int32_t duel_win(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_draw(lua_State* L) {
+LUA_FUNCTION(Draw) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -1183,7 +1186,7 @@ int32_t duel_draw(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_damage(lua_State* L) {
+LUA_FUNCTION(Damage) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -1202,7 +1205,7 @@ int32_t duel_damage(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_recover(lua_State* L) {
+LUA_FUNCTION(Recover) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -1221,12 +1224,12 @@ int32_t duel_recover(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_rd_complete(lua_State* L) {
+LUA_FUNCTION(RDComplete) {
 	const auto pduel = lua_get<duel*>(L);
 	pduel->game_field->core.subunits.splice(pduel->game_field->core.subunits.end(), pduel->game_field->core.recover_damage_reserve);
 	return lua_yield(L, 0);
 }
-int32_t duel_equip(lua_State* L) {
+LUA_FUNCTION(Equip) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	const auto pduel = lua_get<duel*>(L);
@@ -1243,7 +1246,7 @@ int32_t duel_equip(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_equip_complete(lua_State* L) {
+LUA_FUNCTION(EquipComplete) {
 	const auto pduel = lua_get<duel*>(L);
 	card_set etargets;
 	for(auto& equip_card : pduel->game_field->core.equiping_cards) {
@@ -1263,7 +1266,7 @@ int32_t duel_equip_complete(lua_State* L) {
 	pduel->game_field->process_instant_event();
 	return lua_yield(L, 0);
 }
-int32_t duel_get_control(lua_State* L) {
+LUA_FUNCTION(GetControl) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	card* pcard = nullptr;
@@ -1286,7 +1289,7 @@ int32_t duel_get_control(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_swap_control(lua_State* L) {
+LUA_FUNCTION(SwapControl) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	card* pcard1 = nullptr;
@@ -1320,7 +1323,7 @@ int32_t duel_swap_control(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_check_lp_cost(lua_State* L) {
+LUA_FUNCTION(CheckLPCost) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -1330,7 +1333,7 @@ int32_t duel_check_lp_cost(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->check_lp_cost(playerid, cost));
 	return 1;
 }
-int32_t duel_pay_lp_cost(lua_State* L) {
+LUA_FUNCTION(PayLPCost) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -1341,7 +1344,7 @@ int32_t duel_pay_lp_cost(lua_State* L) {
 	pduel->game_field->add_process(PROCESSOR_PAY_LPCOST, 0, 0, 0, playerid, cost);
 	return lua_yield(L, 0);
 }
-int32_t duel_discard_deck(lua_State* L) {
+LUA_FUNCTION(DiscardDeck) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -1354,7 +1357,7 @@ int32_t duel_discard_deck(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_discard_hand(lua_State* L) {
+LUA_FUNCTION(DiscardHand) {
 	check_action_permission(L);
 	check_param_count(L, 5);
 	if(!lua_isnoneornil(L, 2))
@@ -1385,19 +1388,19 @@ int32_t duel_discard_hand(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_disable_shuffle_check(lua_State* L) {
+LUA_FUNCTION(DisableShuffleCheck) {
 	const auto pduel = lua_get<duel*>(L);
 	bool disable = lua_get<bool, true>(L, 1);
 	pduel->game_field->core.shuffle_check_disabled = disable;
 	return 0;
 }
-int32_t duel_disable_self_destroy_check(lua_State* L) {
+LUA_FUNCTION(DisableSelfDestroyCheck) {
 	const auto pduel = lua_get<duel*>(L);
 	bool disable = lua_get<bool, true>(L, 1);
 	pduel->game_field->core.selfdes_disabled = disable;
 	return 0;
 }
-int32_t duel_shuffle_deck(lua_State* L) {
+LUA_FUNCTION(ShuffleDeck) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -1406,7 +1409,7 @@ int32_t duel_shuffle_deck(lua_State* L) {
 	pduel->game_field->shuffle(playerid, LOCATION_DECK);
 	return 0;
 }
-int32_t duel_shuffle_extra(lua_State* L) {
+LUA_FUNCTION(ShuffleExtra) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if (playerid != 0 && playerid != 1)
@@ -1415,7 +1418,7 @@ int32_t duel_shuffle_extra(lua_State* L) {
 	pduel->game_field->shuffle(playerid, LOCATION_EXTRA);
 	return 0;
 }
-int32_t duel_shuffle_hand(lua_State* L) {
+LUA_FUNCTION(ShuffleHand) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -1424,7 +1427,7 @@ int32_t duel_shuffle_hand(lua_State* L) {
 	pduel->game_field->shuffle(playerid, LOCATION_HAND);
 	return 0;
 }
-int32_t duel_shuffle_setcard(lua_State* L) {
+LUA_FUNCTION(ShuffleSetCard) {
 	check_param_count(L, 1);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	if(pgroup->container.size() <= 0)
@@ -1490,7 +1493,7 @@ int32_t duel_shuffle_setcard(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_change_attacker(lua_State* L) {
+LUA_FUNCTION(ChangeAttacker) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto new_attacker = lua_get<card*, true>(L, 1);
@@ -1514,7 +1517,7 @@ int32_t duel_change_attacker(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_change_attack_target(lua_State* L) {
+LUA_FUNCTION(ChangeAttackTarget) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto target = lua_get<card*>(L, 1);
@@ -1558,13 +1561,13 @@ int32_t duel_change_attack_target(lua_State* L) {
 		lua_pushboolean(L, 0);
 	return 1;
 }
-int32_t duel_attack_cost_paid(lua_State* L) {
+LUA_FUNCTION(AttackCostPaid) {
 	const auto pduel = lua_get<duel*>(L);
 	auto paid = lua_get<uint8_t, 1>(L, 1);
 	pduel->game_field->core.attack_cost_paid = paid;
 	return 0;
 }
-int32_t duel_force_attack(lua_State* L) {
+LUA_FUNCTION(ForceAttack) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
@@ -1575,7 +1578,7 @@ int32_t duel_force_attack(lua_State* L) {
 	pduel->game_field->core.forced_attack_target = attack_target;
 	return lua_yield(L, 0);
 }
-int32_t duel_calculate_damage(lua_State* L) {
+LUA_FUNCTION(CalculateDamage) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
@@ -1587,7 +1590,7 @@ int32_t duel_calculate_damage(lua_State* L) {
 	pduel->game_field->add_process(PROCESSOR_DAMAGE_STEP, 0, (effect*)attacker, (group*)attack_target, 0, new_attack);
 	return lua_yield(L, 0);
 }
-int32_t duel_get_battle_damage(lua_State* L) {
+LUA_FUNCTION(GetBattleDamage) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -1596,7 +1599,7 @@ int32_t duel_get_battle_damage(lua_State* L) {
 	lua_pushinteger(L, pduel->game_field->core.battle_damage[playerid]);
 	return 1;
 }
-int32_t duel_change_battle_damage(lua_State* L) {
+LUA_FUNCTION(ChangeBattleDamage) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -1609,7 +1612,7 @@ int32_t duel_change_battle_damage(lua_State* L) {
 	pduel->game_field->core.battle_damage[playerid] = dam;
 	return 0;
 }
-int32_t duel_change_target(lua_State* L) {
+LUA_FUNCTION(ChangeTargetCard) {
 	check_param_count(L, 2);
 	auto count = lua_get<uint8_t>(L, 1);
 	auto pgroup = lua_get<group*, true>(L, 2);
@@ -1617,7 +1620,7 @@ int32_t duel_change_target(lua_State* L) {
 	pduel->game_field->change_target(count, pgroup);
 	return 0;
 }
-int32_t duel_change_target_player(lua_State* L) {
+LUA_FUNCTION(ChangeTargetPlayer) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 2);
 	if(playerid != 0 && playerid != 1)
@@ -1627,7 +1630,7 @@ int32_t duel_change_target_player(lua_State* L) {
 	pduel->game_field->change_target_player(count, playerid);
 	return 0;
 }
-int32_t duel_change_target_param(lua_State* L) {
+LUA_FUNCTION(ChangeTargetParam) {
 	check_param_count(L, 2);
 	auto count = lua_get<uint8_t>(L, 1);
 	auto param = lua_get<int32_t>(L, 2);
@@ -1635,7 +1638,7 @@ int32_t duel_change_target_param(lua_State* L) {
 	pduel->game_field->change_target_param(count, param);
 	return 0;
 }
-int32_t duel_break_effect(lua_State* L) {
+LUA_FUNCTION(BreakEffect) {
 	check_action_permission(L);
 	const auto pduel = lua_get<duel*>(L);
 	pduel->game_field->break_effect();
@@ -1643,7 +1646,7 @@ int32_t duel_break_effect(lua_State* L) {
 	pduel->game_field->process_instant_event();
 	return lua_yield(L, 0);
 }
-int32_t duel_change_effect(lua_State* L) {
+LUA_FUNCTION(ChangeChainOperation) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	const auto pduel = lua_get<duel*>(L);
@@ -1651,19 +1654,19 @@ int32_t duel_change_effect(lua_State* L) {
 	pduel->game_field->change_chain_effect(lua_get<uint8_t>(L, 1), pf);
 	return 0;
 }
-int32_t duel_negate_activate(lua_State* L) {
+LUA_FUNCTION(NegateActivation) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	lua_pushboolean(L, pduel->game_field->negate_chain(lua_get<uint8_t>(L, 1)));
 	return 1;
 }
-int32_t duel_negate_effect(lua_State* L) {
+LUA_FUNCTION(NegateEffect) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	lua_pushboolean(L, pduel->game_field->disable_chain(lua_get<uint8_t>(L, 1)));
 	return 1;
 }
-int32_t duel_negate_related_chain(lua_State* L) {
+LUA_FUNCTION(NegateRelatedChain) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -1685,7 +1688,7 @@ int32_t duel_negate_related_chain(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_disable_summon(lua_State* L) {
+LUA_FUNCTION(NegateSummon) {
 	check_param_count(L, 1);
 	card* pcard = nullptr;
 	group* pgroup = nullptr;
@@ -1723,7 +1726,7 @@ int32_t duel_disable_summon(lua_State* L) {
 	pduel->game_field->process_instant_event();
 	return 0;
 }
-int32_t duel_increase_summon_count(lua_State* L) {
+LUA_FUNCTION(IncreaseSummonedCount) {
 	card* pcard = 0;
 	effect* pextra = 0;
 	if(lua_gettop(L) > 0)
@@ -1736,7 +1739,7 @@ int32_t duel_increase_summon_count(lua_State* L) {
 		++pduel->game_field->core.summon_count[playerid];
 	return 0;
 }
-int32_t duel_check_summon_count(lua_State* L) {
+LUA_FUNCTION(CheckSummonedCount) {
 	card* pcard = 0;
 	if(lua_gettop(L) > 0)
 		pcard = lua_get<card*, true>(L, 1);
@@ -1749,7 +1752,7 @@ int32_t duel_check_summon_count(lua_State* L) {
 		lua_pushboolean(L, 0);
 	return 1;
 }
-int32_t duel_get_location_count(lua_State* L) {
+LUA_FUNCTION(GetLocationCount) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto location = lua_get<uint8_t>(L, 2);
@@ -1764,7 +1767,7 @@ int32_t duel_get_location_count(lua_State* L) {
 	lua_pushinteger(L, list);
 	return 2;
 }
-int32_t duel_get_mzone_count(lua_State* L) {
+LUA_FUNCTION(GetMZoneCount) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -1807,7 +1810,7 @@ int32_t duel_get_mzone_count(lua_State* L) {
 	}
 	return 2;
 }
-int32_t duel_get_location_count_fromex(lua_State* L) {
+LUA_FUNCTION(GetLocationCountFromEx) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -1869,7 +1872,7 @@ int32_t duel_get_location_count_fromex(lua_State* L) {
 	}
 	return 2;
 }
-int32_t duel_get_usable_mzone_count(lua_State* L) {
+LUA_FUNCTION(GetUsableMZoneCount) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -1888,7 +1891,7 @@ int32_t duel_get_usable_mzone_count(lua_State* L) {
 	lua_pushinteger(L, count);
 	return 1;
 }
-int32_t duel_get_linked_group(lua_State* L) {
+LUA_FUNCTION(GetLinkedGroup) {
 	check_param_count(L, 3);
 	auto rplayer = lua_get<uint8_t>(L, 1);
 	if(rplayer != 0 && rplayer != 1)
@@ -1906,7 +1909,7 @@ int32_t duel_get_linked_group(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t duel_get_linked_group_count(lua_State* L) {
+LUA_FUNCTION(GetLinkedGroupCount) {
 	check_param_count(L, 3);
 	auto rplayer = lua_get<uint8_t>(L, 1);
 	if(rplayer != 0 && rplayer != 1)
@@ -1923,7 +1926,7 @@ int32_t duel_get_linked_group_count(lua_State* L) {
 	lua_pushinteger(L, cset.size());
 	return 1;
 }
-int32_t duel_get_linked_zone(lua_State* L) {
+LUA_FUNCTION(GetLinkedZone) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -1932,7 +1935,7 @@ int32_t duel_get_linked_zone(lua_State* L) {
 	lua_pushinteger(L, pduel->game_field->get_linked_zone(playerid));
 	return 1;
 }
-int32_t duel_get_free_linked_zone(lua_State* L) {
+LUA_FUNCTION(GetFreeLinkedZone) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -1941,7 +1944,7 @@ int32_t duel_get_free_linked_zone(lua_State* L) {
 	lua_pushinteger(L, pduel->game_field->get_linked_zone(playerid, true));
 	return 1;
 }
-int32_t duel_get_field_card(lua_State* L) {
+LUA_FUNCTION(GetFieldCard) {
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto location = lua_get<uint16_t>(L, 2);
@@ -1955,7 +1958,7 @@ int32_t duel_get_field_card(lua_State* L) {
 	interpreter::pushobject(L, pcard);
 	return 1;
 }
-int32_t duel_check_location(lua_State* L) {
+LUA_FUNCTION(CheckLocation) {
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto location = lua_get<uint16_t>(L, 2);
@@ -1966,14 +1969,14 @@ int32_t duel_check_location(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->is_location_useable(playerid, location, sequence));
 	return 1;
 }
-int32_t duel_get_current_chain(lua_State* L) {
+LUA_FUNCTION(GetCurrentChain) {
 	const auto pduel = lua_get<duel*>(L);
 	const auto real = lua_get<bool, false>(L, 1);
 	const auto& core = pduel->game_field->core;
 	lua_pushinteger(L, real ? core.real_chain_count : core.current_chain.size());
 	return 1;
 }
-int32_t duel_get_chain_info(lua_State* L) {
+LUA_FUNCTION(GetChainInfo) {
 	check_param_count(L, 1);
 	uint32_t args = lua_gettop(L) - 1;
 	const auto pduel = lua_get<duel*>(L);
@@ -2061,7 +2064,7 @@ int32_t duel_get_chain_info(lua_State* L) {
 	}
 	return args;
 }
-int32_t duel_get_chain_event(lua_State* L) {
+LUA_FUNCTION(GetChainEvent) {
 	check_param_count(L, 1);
 	auto count = lua_get<uint8_t>(L, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -2076,7 +2079,7 @@ int32_t duel_get_chain_event(lua_State* L) {
 	lua_pushinteger(L, ch->evt.reason_player);
 	return 6;
 }
-int32_t duel_get_first_target(lua_State* L) {
+LUA_FUNCTION(GetFirstTarget) {
 	const auto pduel = lua_get<duel*>(L);
 	chain* ch = pduel->game_field->get_chain(0);
 	if(!ch || !ch->target_cards || ch->target_cards->container.size() == 0)
@@ -2085,12 +2088,12 @@ int32_t duel_get_first_target(lua_State* L) {
 		interpreter::pushobject(L, pcard);
 	return ch->target_cards->container.size();
 }
-int32_t duel_get_current_phase(lua_State* L) {
+LUA_FUNCTION(GetCurrentPhase) {
 	const auto pduel = lua_get<duel*>(L);
 	lua_pushinteger(L, pduel->game_field->infos.phase);
 	return 1;
 }
-int32_t duel_skip_phase(lua_State* L) {
+LUA_FUNCTION(SkipPhase) {
 	check_param_count(L, 4);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -2131,29 +2134,29 @@ int32_t duel_skip_phase(lua_State* L) {
 	pduel->game_field->add_effect(peffect, playerid);
 	return 0;
 }
-int32_t duel_is_attack_cost_paid(lua_State* L) {
+LUA_FUNCTION(IsAttackCostPaid) {
 	const auto pduel = lua_get<duel*>(L);
 	lua_pushinteger(L, pduel->game_field->core.attack_cost_paid);
 	return 1;
 }
-int32_t duel_is_damage_calculated(lua_State* L) {
+LUA_FUNCTION(IsDamageCalculated) {
 	const auto pduel = lua_get<duel*>(L);
 	lua_pushboolean(L, pduel->game_field->core.damage_calculated);
 	return 1;
 }
-int32_t duel_get_attacker(lua_State* L) {
+LUA_FUNCTION(GetAttacker) {
 	const auto pduel = lua_get<duel*>(L);
 	card* pcard = pduel->game_field->core.attacker;
 	interpreter::pushobject(L, pcard);
 	return 1;
 }
-int32_t duel_get_attack_target(lua_State* L) {
+LUA_FUNCTION(GetAttackTarget) {
 	const auto pduel = lua_get<duel*>(L);
 	card* pcard = pduel->game_field->core.attack_target;
 	interpreter::pushobject(L, pcard);
 	return 1;
 }
-int32_t duel_get_battle_monster(lua_State* L) {
+LUA_FUNCTION(GetBattleMonster) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -2170,7 +2173,7 @@ int32_t duel_get_battle_monster(lua_State* L) {
 	}
 	return 2;
 }
-int32_t duel_disable_attack(lua_State* L) {
+LUA_FUNCTION(NegateAttack) {
 	const auto pduel = lua_get<duel*>(L);
 	pduel->game_field->add_process(PROCESSOR_ATTACK_DISABLE, 0, 0, 0, 0, 0);
 	return lua_yieldk(L, 0, 0, [](lua_State* L, int32_t/* status*/, lua_KContext/* ctx*/) {
@@ -2178,7 +2181,7 @@ int32_t duel_disable_attack(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_chain_attack(lua_State* L) {
+LUA_FUNCTION(ChainAttack) {
 	const auto pduel = lua_get<duel*>(L);
 	pduel->game_field->core.chain_attack = TRUE;
 	pduel->game_field->core.chain_attacker_id = pduel->game_field->core.attacker->fieldid;
@@ -2186,7 +2189,7 @@ int32_t duel_chain_attack(lua_State* L) {
 		pduel->game_field->core.chain_attack_target = lua_get<card*, true>(L, 1);
 	return 0;
 }
-int32_t duel_readjust(lua_State* L) {
+LUA_FUNCTION(Readjust) {
 	const auto pduel = lua_get<duel*>(L);
 	card* adjcard = pduel->game_field->core.reason_effect->get_handler();
 	auto& readj_map = pduel->game_field->core.readjust_map[adjcard];
@@ -2198,7 +2201,7 @@ int32_t duel_readjust(lua_State* L) {
 	pduel->game_field->core.re_adjust = TRUE;
 	return 0;
 }
-int32_t duel_adjust_instantly(lua_State* L) {
+LUA_FUNCTION(AdjustInstantly) {
 	const auto pduel = lua_get<duel*>(L);
 	if(lua_gettop(L) > 0) {
 		auto pcard = lua_get<card*, true>(L, 1);
@@ -2212,7 +2215,7 @@ int32_t duel_adjust_instantly(lua_State* L) {
  * \param playerid, location1, location2
  * \return Group
  */
-int32_t duel_get_field_group(lua_State* L) {
+LUA_FUNCTION(GetFieldGroup) {
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto location1 = lua_get<uint16_t>(L, 2);
@@ -2228,7 +2231,7 @@ int32_t duel_get_field_group(lua_State* L) {
  * \param playerid, location1, location2
  * \return Integer
  */
-int32_t duel_get_field_group_count(lua_State* L) {
+LUA_FUNCTION(GetFieldGroupCount) {
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto location1 = lua_get<uint16_t>(L, 2);
@@ -2243,7 +2246,7 @@ int32_t duel_get_field_group_count(lua_State* L) {
  * \param playerid, count
  * \return Group
  */
-int32_t duel_get_decktop_group(lua_State* L) {
+LUA_FUNCTION(GetDecktopGroup) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto count = lua_get<uint32_t>(L, 2);
@@ -2260,7 +2263,7 @@ int32_t duel_get_decktop_group(lua_State* L) {
  * \param playerid, count
  * \return Group
  */
-int32_t duel_get_extratop_group(lua_State* L) {
+LUA_FUNCTION(GetExtraTopGroup) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto count = lua_get<uint32_t>(L, 2);
@@ -2277,7 +2280,7 @@ int32_t duel_get_extratop_group(lua_State* L) {
 * \param filter_func, self, location1, location2, exception card, (extraargs...)
 * \return Group
 */
-int32_t duel_get_matching_group(lua_State* L) {
+LUA_FUNCTION(GetMatchingGroup) {
 	check_param_count(L, 5);
 	if(!lua_isnoneornil(L, 1))
 		check_param(L, PARAM_TYPE_FUNCTION, 1);
@@ -2300,7 +2303,7 @@ int32_t duel_get_matching_group(lua_State* L) {
 * \param filter_func, self, location1, location2, exception card, (extraargs...)
 * \return Integer
 */
-int32_t duel_get_matching_count(lua_State* L) {
+LUA_FUNCTION(GetMatchingGroupCount) {
 	check_param_count(L, 5);
 	if(!lua_isnoneornil(L, 1))
 		check_param(L, PARAM_TYPE_FUNCTION, 1);
@@ -2324,7 +2327,7 @@ int32_t duel_get_matching_count(lua_State* L) {
 * \param filter_func, self, location1, location2, exception card, (extraargs...)
 * \return Card | nil
 */
-int32_t duel_get_first_matching_card(lua_State* L) {
+LUA_FUNCTION(GetFirstMatchingCard) {
 	check_param_count(L, 5);
 	if(!lua_isnoneornil(L, 1))
 		check_param(L, PARAM_TYPE_FUNCTION, 1);
@@ -2349,7 +2352,7 @@ int32_t duel_get_first_matching_card(lua_State* L) {
 * \param filter_func, self, location1, location2, count, exception card, (extraargs...)
 * \return boolean
 */
-int32_t duel_is_existing_matching_card(lua_State* L) {
+LUA_FUNCTION(IsExistingMatchingCard) {
 	check_param_count(L, 6);
 	if(!lua_isnoneornil(L, 1))
 		check_param(L, PARAM_TYPE_FUNCTION, 1);
@@ -2371,7 +2374,7 @@ int32_t duel_is_existing_matching_card(lua_State* L) {
 * \param playerid, filter_func, self, location1, location2, min, max, exception card, (extraargs...)
 * \return Group
 */
-int32_t duel_select_matching_cards(lua_State* L) {
+LUA_FUNCTION(SelectMatchingCard) {
 	check_action_permission(L);
 	check_param_count(L, 8);
 	if(!lua_isnoneornil(L, 2))
@@ -2403,7 +2406,7 @@ int32_t duel_select_matching_cards(lua_State* L) {
 	pduel->game_field->add_process(PROCESSOR_SELECT_CARD, 0, 0, 0, playerid + (cancelable << 16), min + (max << 16));
 	return lua_yieldk(L, 0, (lua_KContext)cancelable, push_return_cards);
 }
-int32_t duel_select_cards_code(lua_State * L) {
+LUA_FUNCTION(SelectCardsFromCodes) {
 	check_action_permission(L);
 	check_param_count(L, 6);
 	const auto pduel = lua_get<duel*>(L);
@@ -2447,7 +2450,7 @@ int32_t duel_select_cards_code(lua_State * L) {
 * \param playerid
 * \return Group
 */
-int32_t duel_get_release_group(lua_State* L) {
+LUA_FUNCTION(GetReleaseGroup) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -2465,7 +2468,7 @@ int32_t duel_get_release_group(lua_State* L) {
 * \param playerid
 * \return Integer
 */
-int32_t duel_get_release_group_count(lua_State* L) {
+LUA_FUNCTION(GetReleaseGroupCount) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -2518,10 +2521,10 @@ static int32_t check_release_group(lua_State* L, uint8_t use_hand) {
 	return 1;
 
 }
-int32_t duel_check_release_group(lua_State* L) {
+LUA_FUNCTION(CheckReleaseGroup) {
 	return check_release_group(L, FALSE);
 }
-int32_t duel_check_release_group_ex(lua_State* L) {
+LUA_FUNCTION(CheckReleaseGroupEx) {
 	return check_release_group(L, TRUE);
 }
 static int32_t select_release_group(lua_State* L, uint8_t use_hand) {
@@ -2569,10 +2572,10 @@ static int32_t select_release_group(lua_State* L, uint8_t use_hand) {
 	pduel->game_field->add_process(PROCESSOR_SELECT_RELEASE, 0, 0, (group*)to_check, playerid + (cancelable << 16), (max << 16) + min, check_field + (toplayer << 8) + (zone << 16));
 	return lua_yieldk(L, 0, (lua_KContext)cancelable, push_return_cards);
 }
-int32_t duel_select_release_group(lua_State* L) {
+LUA_FUNCTION(SelectReleaseGroup) {
 	return select_release_group(L, false);
 }
-int32_t duel_select_release_group_ex(lua_State* L) {
+LUA_FUNCTION(SelectReleaseGroupEx) {
 	return select_release_group(L, true);
 }
 /**
@@ -2580,7 +2583,7 @@ int32_t duel_select_release_group_ex(lua_State* L) {
 * \param targetcard
 * \return Group
 */
-int32_t duel_get_tribute_group(lua_State* L) {
+LUA_FUNCTION(GetTributeGroup) {
 	check_param_count(L, 1);
 	auto target = lua_get<card*, true>(L, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -2594,7 +2597,7 @@ int32_t duel_get_tribute_group(lua_State* L) {
 * \param targetcard
 * \return Integer
 */
-int32_t duel_get_tribute_count(lua_State* L) {
+LUA_FUNCTION(GetTributeCount) {
 	check_param_count(L, 1);
 	auto target = lua_get<card*, true>(L, 1);
 	group* mg = 0;
@@ -2605,7 +2608,7 @@ int32_t duel_get_tribute_count(lua_State* L) {
 	lua_pushinteger(L, pduel->game_field->get_summon_release_list(target, nullptr, nullptr, nullptr, mg, ex));
 	return 1;
 }
-int32_t duel_check_tribute(lua_State* L) {
+LUA_FUNCTION(CheckTribute) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto target = lua_get<card*, true>(L, 1);
@@ -2619,7 +2622,7 @@ int32_t duel_check_tribute(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->check_tribute(target, min, max, mg, toplayer, zone));
 	return 1;
 }
-int32_t duel_select_tribute(lua_State* L) {
+LUA_FUNCTION(SelectTribute) {
 	check_action_permission(L);
 	check_param_count(L, 4);
 	auto target = lua_get<card*, true>(L, 2);
@@ -2652,7 +2655,7 @@ int32_t duel_select_tribute(lua_State* L) {
 * \param filter_func, self, location1, location2, exception card, (extraargs...)
 * \return Group
 */
-int32_t duel_get_target_count(lua_State* L) {
+LUA_FUNCTION(GetTargetCount) {
 	check_param_count(L, 5);
 	if(!lua_isnoneornil(L, 1))
 		check_param(L, PARAM_TYPE_FUNCTION, 1);
@@ -2677,7 +2680,7 @@ int32_t duel_get_target_count(lua_State* L) {
 * \param filter_func, self, location1, location2, count, exception card, (extraargs...)
 * \return boolean
 */
-int32_t duel_is_existing_target(lua_State* L) {
+LUA_FUNCTION(IsExistingTarget) {
 	check_param_count(L, 6);
 	if(!lua_isnoneornil(L, 1))
 		check_param(L, PARAM_TYPE_FUNCTION, 1);
@@ -2699,7 +2702,7 @@ int32_t duel_is_existing_target(lua_State* L) {
 * \param playerid, filter_func, self, location1, location2, min, max, exception card, (extraargs...)
 * \return Group
 */
-int32_t duel_select_target(lua_State* L) {
+LUA_FUNCTION(SelectTarget) {
 	check_action_permission(L);
 	check_param_count(L, 8);
 	if(!lua_isnoneornil(L, 2))
@@ -2763,7 +2766,7 @@ int32_t duel_select_target(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_select_fusion_material(lua_State* L) {
+LUA_FUNCTION(SelectFusionMaterial) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -2786,14 +2789,14 @@ int32_t duel_select_fusion_material(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_set_fusion_material(lua_State* L) {
+LUA_FUNCTION(SetFusionMaterial) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	pduel->game_field->core.fusion_materials = pgroup->container;
 	return 0;
 }
-int32_t duel_get_ritual_material(lua_State* L) {
+LUA_FUNCTION(GetRitualMaterial) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -2805,7 +2808,7 @@ int32_t duel_get_ritual_material(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t duel_release_ritual_material(lua_State* L) {
+LUA_FUNCTION(ReleaseRitualMaterial) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -2813,7 +2816,7 @@ int32_t duel_release_ritual_material(lua_State* L) {
 	pduel->game_field->ritual_release(pgroup->container);
 	return lua_yield(L, 0);
 }
-int32_t duel_get_fusion_material(lua_State* L) {
+LUA_FUNCTION(GetFusionMaterial) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -2824,12 +2827,12 @@ int32_t duel_get_fusion_material(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t duel_is_summon_cancelable(lua_State* L) {
+LUA_FUNCTION(IsSummonCancelable) {
 	const auto pduel = lua_get<duel*>(L);
 	lua_pushboolean(L, pduel->game_field->core.summon_cancelable);
 	return 1;
 }
-int32_t duel_set_must_select_cards(lua_State* L) {
+LUA_FUNCTION(SetSelectedCard) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	if(auto pcard = lua_get<card*>(L, 1)) {
@@ -2842,14 +2845,14 @@ int32_t duel_set_must_select_cards(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_grab_must_select_cards(lua_State* L) {
+LUA_FUNCTION(GrabSelectedCard) {
 	const auto pduel = lua_get<duel*>(L);
 	group* pgroup = pduel->new_group(pduel->game_field->core.must_select_cards);
 	pduel->game_field->core.must_select_cards.clear();
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t duel_set_target_card(lua_State* L) {
+LUA_FUNCTION(SetTargetCard) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	card* pcard = nullptr;
@@ -2893,14 +2896,14 @@ int32_t duel_set_target_card(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_clear_target_card(lua_State* L) {
+LUA_FUNCTION(ClearTargetCard) {
 	const auto pduel = lua_get<duel*>(L);
 	chain* ch = pduel->game_field->get_chain(0);
 	if(ch && ch->target_cards)
 		ch->target_cards->container.clear();
 	return 0;
 }
-int32_t duel_set_target_player(lua_State* L) {
+LUA_FUNCTION(SetTargetPlayer) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -2910,7 +2913,7 @@ int32_t duel_set_target_player(lua_State* L) {
 		ch->target_player = playerid;
 	return 0;
 }
-int32_t duel_set_target_param(lua_State* L) {
+LUA_FUNCTION(SetTargetParam) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	auto param = lua_get<uint32_t>(L, 1);
@@ -2925,7 +2928,7 @@ int32_t duel_set_target_param(lua_State* L) {
 * \param target_group, target_count, target_player, targ
 * \return N/A
 */
-int32_t duel_set_operation_info(lua_State* L) {
+LUA_FUNCTION(SetOperationInfo) {
 	check_action_permission(L);
 	check_param_count(L, 6);
 	const auto pduel = lua_get<duel*>(L);
@@ -2955,7 +2958,7 @@ int32_t duel_set_operation_info(lua_State* L) {
 	ch->opinfos[cate] = std::move(opt);
 	return 0;
 }
-int32_t duel_get_operation_info(lua_State* L) {
+LUA_FUNCTION(GetOperationInfo) {
 	check_param_count(L, 2);
 	auto ct = lua_get<uint32_t>(L, 1);
 	auto cate = lua_get<uint32_t>(L, 2);
@@ -2980,7 +2983,7 @@ int32_t duel_get_operation_info(lua_State* L) {
 		return 1;
 	}
 }
-int32_t duel_set_possible_operation_info(lua_State* L) {
+LUA_FUNCTION(SetPossibleOperationInfo) {
 	check_action_permission(L);
 	check_param_count(L, 6);
 	const auto pduel = lua_get<duel*>(L);
@@ -3004,7 +3007,7 @@ int32_t duel_set_possible_operation_info(lua_State* L) {
 	ch->possibleopinfos[cate] = std::move(opt);
 	return 0;
 }
-int32_t duel_get_possible_operation_info(lua_State* L) {
+LUA_FUNCTION(GetPossibleOperationInfo) {
 	check_param_count(L, 2);
 	auto ct = lua_get<uint32_t>(L, 1);
 	auto cate = lua_get<uint32_t>(L, 2);
@@ -3029,7 +3032,7 @@ int32_t duel_get_possible_operation_info(lua_State* L) {
 		return 1;
 	}
 }
-int32_t duel_get_operation_count(lua_State* L) {
+LUA_FUNCTION(GetOperationCount) {
 	check_param_count(L, 1);
 	auto ct = lua_get<uint32_t>(L, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -3039,7 +3042,7 @@ int32_t duel_get_operation_count(lua_State* L) {
 	lua_pushinteger(L, ch->opinfos.size());
 	return 1;
 }
-int32_t duel_clear_operation_info(lua_State* L) {
+LUA_FUNCTION(ClearOperationInfo) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	auto ct = lua_get<uint32_t>(L, 1);
@@ -3059,7 +3062,7 @@ int32_t duel_clear_operation_info(lua_State* L) {
 	ch->possibleopinfos.clear();
 	return 0;
 }
-int32_t duel_overlay(lua_State* L) {
+LUA_FUNCTION(Overlay) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
@@ -3088,7 +3091,7 @@ int32_t duel_overlay(lua_State* L) {
 		pduel->game_field->adjust_all();
 	return lua_yield(L, 0);
 }
-int32_t duel_get_overlay_group(lua_State* L) {
+LUA_FUNCTION(GetOverlayGroup) {
 	check_param_count(L, 3);
 	auto rplayer = lua_get<uint8_t>(L, 1);
 	if(rplayer != 0 && rplayer != 1)
@@ -3102,7 +3105,7 @@ int32_t duel_get_overlay_group(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t duel_get_overlay_count(lua_State* L) {
+LUA_FUNCTION(GetOverlayCount) {
 	check_param_count(L, 3);
 	auto rplayer = lua_get<uint8_t>(L, 1);
 	if(rplayer != 0 && rplayer != 1)
@@ -3114,7 +3117,7 @@ int32_t duel_get_overlay_count(lua_State* L) {
 	lua_pushinteger(L, pduel->game_field->get_overlay_count(rplayer, self, oppo, pgroup));
 	return 1;
 }
-int32_t duel_check_remove_overlay_card(lua_State* L) {
+LUA_FUNCTION(CheckRemoveOverlayCard) {
 	check_param_count(L, 5);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -3128,7 +3131,7 @@ int32_t duel_check_remove_overlay_card(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->is_player_can_remove_overlay_card(playerid, pgroup, self, oppo, count, reason));
 	return 1;
 }
-int32_t duel_remove_overlay_card(lua_State* L) {
+LUA_FUNCTION(RemoveOverlayCard) {
 	check_action_permission(L);
 	check_param_count(L, 6);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -3147,7 +3150,7 @@ int32_t duel_remove_overlay_card(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_hint(lua_State* L) {
+LUA_FUNCTION(Hint) {
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 2);
 	if(playerid != 0 && playerid != 1)
@@ -3163,7 +3166,7 @@ int32_t duel_hint(lua_State* L) {
 	message->write<uint64_t>(desc);
 	return 0;
 }
-int32_t duel_hint_selection(lua_State* L) {
+LUA_FUNCTION(HintSelection) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	card* pcard = nullptr;
@@ -3182,7 +3185,7 @@ int32_t duel_hint_selection(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_select_effect_yesno(lua_State* L) {
+LUA_FUNCTION(SelectEffectYesNo) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 2);
@@ -3197,7 +3200,7 @@ int32_t duel_select_effect_yesno(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_select_yesno(lua_State* L) {
+LUA_FUNCTION(SelectYesNo) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -3211,7 +3214,7 @@ int32_t duel_select_yesno(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_select_option(lua_State* L) {
+LUA_FUNCTION(SelectOption) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	uint32_t count = lua_gettop(L) - 1;
@@ -3238,7 +3241,7 @@ int32_t duel_select_option(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_select_position(lua_State* L) {
+LUA_FUNCTION(SelectPosition) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	auto pcard = lua_get<card*, true>(L, 2);
@@ -3251,7 +3254,7 @@ int32_t duel_select_position(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_select_disable_field(lua_State* L) {
+LUA_FUNCTION(SelectDisableField) {
 	check_action_permission(L);
 	check_param_count(L, 5);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -3360,7 +3363,7 @@ int32_t duel_select_disable_field(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_select_field_zone(lua_State* L) {
+LUA_FUNCTION(SelectFieldZone) {
 	check_action_permission(L);
 	check_param_count(L, 4);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -3403,7 +3406,7 @@ int32_t duel_select_field_zone(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_announce_race(lua_State* L) {
+LUA_FUNCTION(AnnounceRace) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -3416,7 +3419,7 @@ int32_t duel_announce_race(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_announce_attribute(lua_State* L) {
+LUA_FUNCTION(AnnounceAttribute) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -3429,7 +3432,7 @@ int32_t duel_announce_attribute(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_announce_level(lua_State* L) {
+LUA_FUNCTION(AnnounceLevel) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -3467,7 +3470,7 @@ int32_t duel_announce_level(lua_State* L) {
 		return 2;
 	});
 }
-int32_t duel_announce_card(lua_State* L) {
+LUA_FUNCTION(AnnounceCard) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -3539,7 +3542,7 @@ int32_t duel_announce_card(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_announce_type(lua_State* L) {
+LUA_FUNCTION(AnnounceType) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -3560,7 +3563,7 @@ int32_t duel_announce_type(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_announce_number(lua_State* L) {
+LUA_FUNCTION(AnnounceNumber) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -3576,7 +3579,7 @@ int32_t duel_announce_number(lua_State* L) {
 		return 2;
 	});
 }
-int32_t duel_announce_coin(lua_State* L) {
+LUA_FUNCTION(AnnounceCoin) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -3596,7 +3599,7 @@ int32_t duel_announce_coin(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_toss_coin(lua_State* L) {
+LUA_FUNCTION(TossCoin) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -3615,7 +3618,7 @@ int32_t duel_toss_coin(lua_State* L) {
 		return count;
 	});
 }
-int32_t duel_toss_dice(lua_State* L) {
+LUA_FUNCTION(TossDice) {
 	check_action_permission(L);
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -3638,7 +3641,7 @@ int32_t duel_toss_dice(lua_State* L) {
 		return count1 + count2;
 	});
 }
-int32_t duel_rock_paper_scissors(lua_State* L) {
+LUA_FUNCTION(RockPaperScissors) {
 	const auto pduel = lua_get<duel*>(L);
 	uint8_t repeat = lua_get<bool, true>(L, 1);
 	pduel->game_field->add_process(PROCESSOR_ROCK_PAPER_SCISSORS, 0, 0, 0, repeat, 0);
@@ -3647,19 +3650,19 @@ int32_t duel_rock_paper_scissors(lua_State* L) {
 		return 1;
 	});
 }
-int32_t duel_get_coin_result(lua_State* L) {
+LUA_FUNCTION(GetCoinResult) {
 	const auto pduel = lua_get<duel*>(L);
 	for(const auto& coin : pduel->game_field->core.coin_result)
 		lua_pushinteger(L, coin);
 	return 5;
 }
-int32_t duel_get_dice_result(lua_State* L) {
+LUA_FUNCTION(GetDiceResult) {
 	const auto pduel = lua_get<duel*>(L);
 	for(const auto& dice : pduel->game_field->core.dice_result)
 		lua_pushinteger(L, dice);
 	return 5;
 }
-int32_t duel_set_coin_result(lua_State* L) {
+LUA_FUNCTION(SetCoinResult) {
 	const auto pduel = lua_get<duel*>(L);
 	for(int32_t i = 0; i < 5; ++i) {
 		auto res = lua_get<uint8_t>(L, i + 1);
@@ -3669,7 +3672,7 @@ int32_t duel_set_coin_result(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_set_dice_result(lua_State* L) {
+LUA_FUNCTION(SetDiceResult) {
 	const auto pduel = lua_get<duel*>(L);
 	for(int32_t i = 0; i < 5; ++i) {
 		auto res = lua_get<uint8_t>(L, i + 1);
@@ -3677,14 +3680,14 @@ int32_t duel_set_dice_result(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_is_duel_type(lua_State* L) {
+LUA_FUNCTION(IsDuelType) {
 	check_param_count(L, 1);
 	auto duel_type = lua_get<uint64_t>(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	lua_pushboolean(L, pduel->game_field->is_flag(duel_type));
 	return 1;
 }
-int32_t duel_is_player_affected_by_effect(lua_State* L) {
+LUA_FUNCTION(IsPlayerAffectedByEffect) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3697,7 +3700,7 @@ int32_t duel_is_player_affected_by_effect(lua_State* L) {
 	interpreter::pushobject(L, peffect);
 	return 1;
 }
-int32_t duel_get_player_effect(lua_State* L) {
+LUA_FUNCTION(GetPlayerEffect) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3713,7 +3716,7 @@ int32_t duel_get_player_effect(lua_State* L) {
 	}
 	return count;
 }
-int32_t duel_is_player_can_draw(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanDraw) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3729,7 +3732,7 @@ int32_t duel_is_player_can_draw(lua_State* L) {
 		                && (pduel->game_field->player[playerid].list_main.size() >= count));
 	return 1;
 }
-int32_t duel_is_player_can_discard_deck(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanDiscardDeck) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto count = lua_get<uint32_t>(L, 2);
@@ -3741,7 +3744,7 @@ int32_t duel_is_player_can_discard_deck(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->is_player_can_discard_deck(playerid, count));
 	return 1;
 }
-int32_t duel_is_player_can_discard_deck_as_cost(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanDiscardDeckAsCost) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto count = lua_get<uint32_t>(L, 2);
@@ -3753,7 +3756,7 @@ int32_t duel_is_player_can_discard_deck_as_cost(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->is_player_can_discard_deck_as_cost(playerid, count));
 	return 1;
 }
-int32_t duel_is_player_can_summon(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanSummon) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3771,7 +3774,7 @@ int32_t duel_is_player_can_summon(lua_State* L) {
 	}
 	return 1;
 }
-int32_t duel_can_player_set_monster(lua_State* L) {
+LUA_FUNCTION(CanPlayerSetMonster) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3789,7 +3792,7 @@ int32_t duel_can_player_set_monster(lua_State* L) {
 	}
 	return 1;
 }
-int32_t duel_can_player_set_spell_trap(lua_State* L) {
+LUA_FUNCTION(CanPlayerSetSpellTrap) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3806,7 +3809,7 @@ int32_t duel_can_player_set_spell_trap(lua_State* L) {
 	}
 	return 1;
 }
-int32_t duel_is_player_can_spsummon(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanSpecialSummon) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3826,7 +3829,7 @@ int32_t duel_is_player_can_spsummon(lua_State* L) {
 	}
 	return 1;
 }
-int32_t duel_is_player_can_flipsummon(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanFlipSummon) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3843,7 +3846,7 @@ int32_t duel_is_player_can_flipsummon(lua_State* L) {
 	}
 	return 1;
 }
-int32_t duel_is_player_can_spsummon_monster(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanSpecialSummonMonster) {
 	check_param_count(L, 9);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3881,7 +3884,7 @@ int32_t duel_is_player_can_spsummon_monster(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->is_player_can_spsummon_monster(playerid, toplayer, pos, sumtype, &dat));
 	return 1;
 }
-int32_t duel_is_player_can_spsummon_count(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanSpecialSummonCount) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto count = lua_get<uint32_t>(L, 2);
@@ -3893,7 +3896,7 @@ int32_t duel_is_player_can_spsummon_count(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->is_player_can_spsummon_count(playerid, count));
 	return 1;
 }
-int32_t duel_is_player_can_release(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanRelease) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3910,7 +3913,7 @@ int32_t duel_is_player_can_release(lua_State* L) {
 	}
 	return 1;
 }
-int32_t duel_is_player_can_remove(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanRemove) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3928,7 +3931,7 @@ int32_t duel_is_player_can_remove(lua_State* L) {
 	}
 	return 1;
 }
-int32_t duel_is_player_can_send_to_hand(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanSendtoHand) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3945,7 +3948,7 @@ int32_t duel_is_player_can_send_to_hand(lua_State* L) {
 	}
 	return 1;
 }
-int32_t duel_is_player_can_send_to_grave(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanSendtoGrave) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3962,7 +3965,7 @@ int32_t duel_is_player_can_send_to_grave(lua_State* L) {
 	}
 	return 1;
 }
-int32_t duel_is_player_can_send_to_deck(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanSendtoDeck) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -3979,7 +3982,7 @@ int32_t duel_is_player_can_send_to_deck(lua_State* L) {
 	}
 	return 1;
 }
-int32_t duel_is_player_can_additional_summon(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanAdditionalSummon) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1) {
@@ -4028,20 +4031,20 @@ inline int32_t is_player_can_procedure_summon_group(lua_State* L, uint32_t summo
 	lua_pushboolean(L, FALSE);
 	return 1;
 }
-int32_t duel_is_player_can_pendulum_summon(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanPendulumSummon) {
 	return is_player_can_procedure_summon_group(L, SUMMON_TYPE_PENDULUM, 0);
 }
-int32_t duel_is_player_can_procedure_summon_group(lua_State* L) {
+LUA_FUNCTION(IsPlayerCanProcedureSummonGroup) {
 	check_param_count(L, 2);
 	auto sumtype = lua_get<uint32_t>(L, 2);
 	return is_player_can_procedure_summon_group(L, sumtype, 1);
 }
-int32_t duel_is_chain_negatable(lua_State* L) {
+LUA_FUNCTION(IsChainNegatable) {
 	check_param_count(L, 1);
 	lua_pushboolean(L, 1);
 	return 1;
 }
-int32_t duel_is_chain_disablable(lua_State* L) {
+LUA_FUNCTION(IsChainDisablable) {
 	check_param_count(L, 1);
 	auto chaincount = lua_get<uint8_t>(L, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -4052,11 +4055,11 @@ int32_t duel_is_chain_disablable(lua_State* L) {
 	lua_pushboolean(L, 1);
 	return 1;
 }
-int32_t duel_is_chain_solving(lua_State* L) {
+LUA_FUNCTION(IsChainSolving) {
 	lua_pushboolean(L, lua_get<duel*>(L)->game_field->core.chain_solving);
 	return 1;
 }
-int32_t duel_check_chain_target(lua_State* L) {
+LUA_FUNCTION(CheckChainTarget) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto chaincount = lua_get<uint8_t>(L, 1);
@@ -4064,7 +4067,7 @@ int32_t duel_check_chain_target(lua_State* L) {
 	lua_pushboolean(L, pduel->game_field->check_chain_target(chaincount, pcard));
 	return 1;
 }
-int32_t duel_check_chain_uniqueness(lua_State* L) {
+LUA_FUNCTION(CheckChainUniqueness) {
 	const auto pduel = lua_get<duel*>(L);
 	if(pduel->game_field->core.current_chain.size() == 0) {
 		lua_pushboolean(L, 1);
@@ -4076,7 +4079,7 @@ int32_t duel_check_chain_uniqueness(lua_State* L) {
 	lua_pushboolean(L, er.size() == pduel->game_field->core.current_chain.size());
 	return 1;
 }
-int32_t duel_get_activity_count(lua_State* L) {
+LUA_FUNCTION(GetActivityCount) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -4111,12 +4114,12 @@ int32_t duel_get_activity_count(lua_State* L) {
 	}
 	return retct;
 }
-int32_t duel_check_phase_activity(lua_State* L) {
+LUA_FUNCTION(CheckPhaseActivity) {
 	const auto pduel = lua_get<duel*>(L);
 	lua_pushboolean(L, pduel->game_field->core.phase_action);
 	return 1;
 }
-int32_t duel_add_custom_activity_counter(lua_State* L) {
+LUA_FUNCTION(AddCustomActivityCounter) {
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_FUNCTION, 3);
 	auto counter_id = lua_get<uint32_t>(L, 1);
@@ -4133,7 +4136,7 @@ int32_t duel_add_custom_activity_counter(lua_State* L) {
 	counter_map.emplace(counter_id, processor::action_value_t{ counter_filter, 0, 0 });
 	return 0;
 }
-int32_t duel_get_custom_activity_count(lua_State* L) {
+LUA_FUNCTION(GetCustomActivityCount) {
 	check_param_count(L, 3);
 	auto counter_id = lua_get<uint32_t>(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 2);
@@ -4152,7 +4155,7 @@ int32_t duel_get_custom_activity_count(lua_State* L) {
 	return 1;
 }
 
-int32_t duel_get_battled_count(lua_State* L) {
+LUA_FUNCTION(GetBattledCount) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -4161,12 +4164,12 @@ int32_t duel_get_battled_count(lua_State* L) {
 	lua_pushinteger(L, pduel->game_field->core.battled_count[playerid]);
 	return 1;
 }
-int32_t duel_is_able_to_enter_bp(lua_State* L) {
+LUA_FUNCTION(IsAbleToEnterBP) {
 	const auto pduel = lua_get<duel*>(L);
 	lua_pushboolean(L, pduel->game_field->is_able_to_enter_bp());
 	return 1;
 }
-int32_t duel_get_random_number(lua_State* L) {
+LUA_FUNCTION(GetRandomNumber) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	int32_t min = 0;
@@ -4179,11 +4182,11 @@ int32_t duel_get_random_number(lua_State* L) {
 	lua_pushinteger(L, pduel->get_next_integer(min, max));
 	return 1;
 }
-int32_t duel_assume_reset(lua_State* L) {
+LUA_FUNCTION(AssumeReset) {
 	lua_get<duel*>(L)->restore_assumes();
 	return 0;
 }
-int32_t duel_get_card_from_cardid(lua_State* L) {
+LUA_FUNCTION(GetCardFromCardID) {
 	check_param_count(L, 1);
 	auto id = lua_get<uint32_t>(L, 1);
 	auto pduel = lua_get<duel*>(L);
@@ -4195,7 +4198,7 @@ int32_t duel_get_card_from_cardid(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_load_script(lua_State* L) {
+LUA_FUNCTION(LoadScript) {
 	using SLS = duel::SCRIPT_LOAD_STATUS;
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
@@ -4230,7 +4233,7 @@ int32_t duel_load_script(lua_State* L) {
 	lua_setglobal(L, "edopro_exports");
 	return 2;
 }
-int32_t duel_tag_swap(lua_State* L) {
+LUA_FUNCTION(TagSwap) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -4240,7 +4243,7 @@ int32_t duel_tag_swap(lua_State* L) {
 	pduel->game_field->tag_swap(playerid);
 	return 0;
 }
-int32_t duel_get_player_count(lua_State* L) {
+LUA_FUNCTION(GetPlayersCount) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -4249,7 +4252,7 @@ int32_t duel_get_player_count(lua_State* L) {
 	lua_pushinteger(L, pduel->game_field->get_player_count(playerid));
 	return 1;
 }
-int32_t duel_swap_deck_and_grave(lua_State* L) {
+LUA_FUNCTION(SwapDeckAndGrave) {
 	check_action_permission(L);
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
@@ -4259,7 +4262,7 @@ int32_t duel_swap_deck_and_grave(lua_State* L) {
 	pduel->game_field->swap_deck_and_grave(playerid);
 	return 0;
 }
-int32_t duel_majestic_copy(lua_State* L) {
+LUA_FUNCTION(MajesticCopy) {
 	check_param_count(L, 2);
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto ccard = lua_get<card*, true>(L, 2);
@@ -4303,7 +4306,7 @@ int32_t duel_majestic_copy(lua_State* L) {
 	}
 	return 0;
 }
-int32_t duel_get_starting_hand(lua_State* L) {
+LUA_FUNCTION(GetStartingHand) {
 	check_param_count(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
@@ -4312,244 +4315,11 @@ int32_t duel_get_starting_hand(lua_State* L) {
 	lua_pushinteger(L, pduel->game_field->player[playerid].start_count);
 	return 1;
 }
-
-static constexpr luaL_Reg duellib[] = {
-	{ "EnableGlobalFlag", duel_enable_global_flag },
-	{ "GetLP", duel_get_lp },
-	{ "SetLP", duel_set_lp },
-	{ "GetTurnPlayer", duel_get_turn_player },
-	{ "GetTurnCount", duel_get_turn_count },
-	{ "GetDrawCount", duel_get_draw_count },
-	{ "RegisterEffect", duel_register_effect },
-	{ "RegisterFlagEffect", duel_register_flag_effect },
-	{ "GetFlagEffect", duel_get_flag_effect },
-	{ "ResetFlagEffect", duel_reset_flag_effect },
-	{ "SetFlagEffectLabel", duel_set_flag_effect_label },
-	{ "GetFlagEffectLabel", duel_get_flag_effect_label },
-	{ "Destroy", duel_destroy },
-	{ "Remove", duel_remove },
-	{ "SendtoGrave", duel_sendto_grave },
-	{ "SendtoHand", duel_sendto_hand },
-	{ "SendtoDeck", duel_sendto_deck },
-	{ "SendtoExtraP", duel_sendto_extra },
-	{ "Sendto", duel_sendto },
-	{ "RemoveCards", duel_remove_cards },
-	{ "GetOperatedGroup", duel_get_operated_group },
-	{ "Summon", duel_summon },
-	{ "SpecialSummonRule", duel_special_summon_rule },
-	{ "SynchroSummon", duel_synchro_summon },
-	{ "XyzSummon", duel_xyz_summon },
-	{ "LinkSummon", duel_link_summon },
-	{ "ProcedureSummon", duel_procedure_summon },
-	{ "PendulumSummon", duel_pendulum_summon },
-	{ "ProcedureSummonGroup", duel_procedure_summon_group },
-	{ "MSet", duel_setm },
-	{ "SSet", duel_sets },
-	{ "CreateToken", duel_create_token },
-	{ "SpecialSummon", duel_special_summon },
-	{ "SpecialSummonStep", duel_special_summon_step },
-	{ "SpecialSummonComplete", duel_special_summon_complete },
-	{ "IsCanAddCounter", duel_is_can_add_counter },
-	{ "RemoveCounter", duel_remove_counter },
-	{ "IsCanRemoveCounter", duel_is_can_remove_counter },
-	{ "GetCounter", duel_get_counter },
-	{ "ChangePosition", duel_change_form },
-	{ "Release", duel_release },
-	{ "MoveToField", duel_move_to_field },
-	{ "ReturnToField", duel_return_to_field },
-	{ "MoveSequence", duel_move_sequence },
-	{ "SwapSequence", duel_swap_sequence },
-	{ "Activate", duel_activate_effect },
-	{ "SetChainLimit", duel_set_chain_limit },
-	{ "SetChainLimitTillChainEnd", duel_set_chain_limit_p },
-	{ "GetChainMaterial", duel_get_chain_material },
-	{ "ConfirmDecktop", duel_confirm_decktop },
-	{ "ConfirmExtratop", duel_confirm_extratop },
-	{ "ConfirmCards", duel_confirm_cards },
-	{ "SortDecktop", duel_sort_decktop },
-	{ "SortDeckbottom", duel_sort_deckbottom },
-	{ "CheckEvent", duel_check_event },
-	{ "RaiseEvent", duel_raise_event },
-	{ "RaiseSingleEvent", duel_raise_single_event },
-	{ "CheckTiming", duel_check_timing },
-	{ "GetEnvironment", duel_get_environment },
-	{ "IsEnvironment", duel_is_environment },
-	{ "Win", duel_win },
-	{ "Draw", duel_draw },
-	{ "Damage", duel_damage },
-	{ "Recover", duel_recover },
-	{ "RDComplete", duel_rd_complete },
-	{ "Equip", duel_equip },
-	{ "EquipComplete", duel_equip_complete },
-	{ "GetControl", duel_get_control },
-	{ "SwapControl", duel_swap_control },
-	{ "CheckLPCost", duel_check_lp_cost },
-	{ "PayLPCost", duel_pay_lp_cost },
-	{ "DiscardDeck", duel_discard_deck },
-	{ "DiscardHand", duel_discard_hand },
-	{ "DisableShuffleCheck", duel_disable_shuffle_check },
-	{ "DisableSelfDestroyCheck", duel_disable_self_destroy_check },
-	{ "ShuffleDeck", duel_shuffle_deck },
-	{ "ShuffleExtra", duel_shuffle_extra },
-	{ "ShuffleHand", duel_shuffle_hand },
-	{ "ShuffleSetCard", duel_shuffle_setcard },
-	{ "ChangeAttacker", duel_change_attacker },
-	{ "ChangeAttackTarget", duel_change_attack_target },
-	{ "AttackCostPaid", duel_attack_cost_paid },
-	{ "ForceAttack", duel_force_attack },
-	{ "CalculateDamage", duel_calculate_damage },
-	{ "GetBattleDamage", duel_get_battle_damage },
-	{ "ChangeBattleDamage", duel_change_battle_damage },
-	{ "ChangeTargetCard", duel_change_target },
-	{ "ChangeTargetPlayer", duel_change_target_player },
-	{ "ChangeTargetParam", duel_change_target_param },
-	{ "BreakEffect", duel_break_effect },
-	{ "ChangeChainOperation", duel_change_effect },
-	{ "NegateActivation", duel_negate_activate },
-	{ "NegateEffect", duel_negate_effect },
-	{ "NegateRelatedChain", duel_negate_related_chain },
-	{ "NegateSummon", duel_disable_summon },
-	{ "IncreaseSummonedCount", duel_increase_summon_count },
-	{ "CheckSummonedCount", duel_check_summon_count },
-	{ "GetLocationCount", duel_get_location_count },
-	{ "GetMZoneCount", duel_get_mzone_count },
-	{ "GetLocationCountFromEx", duel_get_location_count_fromex },
-	{ "GetUsableMZoneCount", duel_get_usable_mzone_count },
-	{ "GetLinkedGroup", duel_get_linked_group },
-	{ "GetLinkedGroupCount", duel_get_linked_group_count },
-	{ "GetLinkedZone", duel_get_linked_zone },
-	{ "GetFreeLinkedZone", duel_get_free_linked_zone },
-	{ "GetFieldCard", duel_get_field_card },
-	{ "CheckLocation", duel_check_location },
-	{ "GetCurrentChain", duel_get_current_chain },
-	{ "GetChainInfo", duel_get_chain_info },
-	{ "GetChainEvent", duel_get_chain_event },
-	{ "GetFirstTarget", duel_get_first_target },
-	{ "GetCurrentPhase", duel_get_current_phase },
-	{ "SkipPhase", duel_skip_phase },
-	{ "IsAttackCostPaid", duel_is_attack_cost_paid },
-	{ "IsDamageCalculated", duel_is_damage_calculated },
-	{ "GetAttacker", duel_get_attacker },
-	{ "GetAttackTarget", duel_get_attack_target },
-	{ "GetBattleMonster", duel_get_battle_monster },
-	{ "NegateAttack", duel_disable_attack },
-	{ "ChainAttack", duel_chain_attack },
-	{ "Readjust", duel_readjust },
-	{ "AdjustInstantly", duel_adjust_instantly },
-	{ "GetFieldGroup", duel_get_field_group },
-	{ "GetFieldGroupCount", duel_get_field_group_count },
-	{ "GetDecktopGroup", duel_get_decktop_group },
-	{ "GetExtraTopGroup", duel_get_extratop_group },
-	{ "GetMatchingGroup", duel_get_matching_group },
-	{ "GetMatchingGroupCount", duel_get_matching_count },
-	{ "GetFirstMatchingCard", duel_get_first_matching_card },
-	{ "IsExistingMatchingCard", duel_is_existing_matching_card },
-	{ "SelectMatchingCard", duel_select_matching_cards },
-	{ "SelectCardsFromCodes", duel_select_cards_code },
-	{ "GetReleaseGroup", duel_get_release_group },
-	{ "GetReleaseGroupCount", duel_get_release_group_count },
-	{ "CheckReleaseGroup", duel_check_release_group },
-	{ "SelectReleaseGroup", duel_select_release_group },
-	{ "CheckReleaseGroupEx", duel_check_release_group_ex },
-	{ "SelectReleaseGroupEx", duel_select_release_group_ex },
-	{ "GetTributeGroup", duel_get_tribute_group },
-	{ "GetTributeCount", duel_get_tribute_count },
-	{ "CheckTribute", duel_check_tribute },
-	{ "SelectTribute", duel_select_tribute },
-	{ "GetTargetCount", duel_get_target_count },
-	{ "IsExistingTarget", duel_is_existing_target },
-	{ "SelectTarget", duel_select_target },
-	{ "SelectFusionMaterial", duel_select_fusion_material },
-	{ "SetFusionMaterial", duel_set_fusion_material },
-	{ "GetRitualMaterial", duel_get_ritual_material },
-	{ "ReleaseRitualMaterial", duel_release_ritual_material },
-	{ "GetFusionMaterial", duel_get_fusion_material },
-	{ "IsSummonCancelable", duel_is_summon_cancelable },
-	{ "SetSelectedCard", duel_set_must_select_cards },
-	{ "GrabSelectedCard", duel_grab_must_select_cards },
-	{ "SetTargetCard", duel_set_target_card },
-	{ "ClearTargetCard", duel_clear_target_card },
-	{ "SetTargetPlayer", duel_set_target_player },
-	{ "SetTargetParam", duel_set_target_param },
-	{ "SetOperationInfo", duel_set_operation_info },
-	{ "GetOperationInfo", duel_get_operation_info },
-	{ "SetPossibleOperationInfo", duel_set_possible_operation_info },
-	{ "GetPossibleOperationInfo", duel_get_possible_operation_info },
-	{ "GetOperationCount", duel_get_operation_count },
-	{ "ClearOperationInfo", duel_clear_operation_info },
-	{ "Overlay", duel_overlay },
-	{ "GetOverlayGroup", duel_get_overlay_group },
-	{ "GetOverlayCount", duel_get_overlay_count },
-	{ "CheckRemoveOverlayCard", duel_check_remove_overlay_card },
-	{ "RemoveOverlayCard", duel_remove_overlay_card },
-	{ "Hint", duel_hint },
-	{ "HintSelection", duel_hint_selection },
-	{ "SelectEffectYesNo", duel_select_effect_yesno },
-	{ "SelectYesNo", duel_select_yesno },
-	{ "SelectOption", duel_select_option },
-	{ "SelectPosition", duel_select_position },
-	{ "SelectDisableField", duel_select_disable_field },
-	{ "SelectFieldZone", duel_select_field_zone },
-	{ "AnnounceRace", duel_announce_race },
-	{ "AnnounceAttribute", duel_announce_attribute },
-	{ "AnnounceLevel", duel_announce_level },
-	{ "AnnounceCard", duel_announce_card },
-	{ "AnnounceType", duel_announce_type },
-	{ "AnnounceNumber", duel_announce_number },
-	{ "AnnounceCoin", duel_announce_coin },
-	{ "TossCoin", duel_toss_coin },
-	{ "TossDice", duel_toss_dice },
-	{ "RockPaperScissors", duel_rock_paper_scissors },
-	{ "GetCoinResult", duel_get_coin_result },
-	{ "GetDiceResult", duel_get_dice_result },
-	{ "SetCoinResult", duel_set_coin_result },
-	{ "SetDiceResult", duel_set_dice_result },
-	{ "IsDuelType", duel_is_duel_type },
-	{ "IsPlayerAffectedByEffect", duel_is_player_affected_by_effect },
-	{ "GetPlayerEffect", duel_get_player_effect },
-	{ "IsPlayerCanDraw", duel_is_player_can_draw },
-	{ "IsPlayerCanDiscardDeck", duel_is_player_can_discard_deck },
-	{ "IsPlayerCanDiscardDeckAsCost", duel_is_player_can_discard_deck_as_cost },
-	{ "IsPlayerCanSummon", duel_is_player_can_summon },
-	{ "CanPlayerSetMonster", duel_can_player_set_monster },
-	{ "CanPlayerSetSpellTrap", duel_can_player_set_spell_trap },
-	{ "IsPlayerCanSpecialSummon", duel_is_player_can_spsummon },
-	{ "IsPlayerCanFlipSummon", duel_is_player_can_flipsummon },
-	{ "IsPlayerCanSpecialSummonMonster", duel_is_player_can_spsummon_monster },
-	{ "IsPlayerCanSpecialSummonCount", duel_is_player_can_spsummon_count },
-	{ "IsPlayerCanRelease", duel_is_player_can_release },
-	{ "IsPlayerCanRemove", duel_is_player_can_remove },
-	{ "IsPlayerCanSendtoHand", duel_is_player_can_send_to_hand },
-	{ "IsPlayerCanSendtoGrave", duel_is_player_can_send_to_grave },
-	{ "IsPlayerCanSendtoDeck", duel_is_player_can_send_to_deck },
-	{ "IsPlayerCanAdditionalSummon", duel_is_player_can_additional_summon },
-	{ "IsPlayerCanPendulumSummon", duel_is_player_can_pendulum_summon },
-	{ "IsPlayerCanProcedureSummonGroup", duel_is_player_can_procedure_summon_group },
-	{ "IsChainNegatable", duel_is_chain_negatable },
-	{ "IsChainDisablable", duel_is_chain_disablable },
-	{ "IsChainSolving", duel_is_chain_solving },
-	{ "CheckChainTarget", duel_check_chain_target },
-	{ "CheckChainUniqueness", duel_check_chain_uniqueness },
-	{ "GetActivityCount", duel_get_activity_count },
-	{ "CheckPhaseActivity", duel_check_phase_activity },
-	{ "AddCustomActivityCounter", duel_add_custom_activity_counter },
-	{ "GetCustomActivityCount", duel_get_custom_activity_count },
-	{ "GetBattledCount", duel_get_battled_count },
-	{ "IsAbleToEnterBP", duel_is_able_to_enter_bp },
-	{ "TagSwap", duel_tag_swap },
-	{ "GetPlayersCount", duel_get_player_count },
-	{ "SwapDeckAndGrave", duel_swap_deck_and_grave },
-	{ "MajesticCopy", duel_majestic_copy },
-	{ "GetRandomNumber", duel_get_random_number },
-	{ "AssumeReset", duel_assume_reset },
-	{ "GetCardFromCardID", duel_get_card_from_cardid },
-	{ "LoadScript", duel_load_script },
-	{ "GetStartingHand", duel_get_starting_hand },
-	{ nullptr, nullptr }
-};
 }
 
 void scriptlib::push_duel_lib(lua_State* L) {
-	luaL_newlib(L, duellib);
+	static constexpr auto duellib = GET_LUA_FUNCTIONS_ARRAY();
+	lua_createtable(L, 0, duellib.size() - 1);
+	luaL_setfuncs(L, duellib.data(), 0);
 	lua_setglobal(L, "Duel");
 }

--- a/libeffect.cpp
+++ b/libeffect.cpp
@@ -512,6 +512,7 @@ LUA_FUNCTION_EXISTING(IsDeleted, is_deleted_object);
 
 void scriptlib::push_effect_lib(lua_State* L) {
 	static constexpr auto effectlib = GET_LUA_FUNCTIONS_ARRAY();
+	static_assert(effectlib.back().name == nullptr, "");
 	lua_createtable(L, 0, effectlib.size() - 1);
 	luaL_setfuncs(L, effectlib.data(), 0);
 	lua_pushstring(L, "__index");

--- a/libeffect.cpp
+++ b/libeffect.cpp
@@ -12,11 +12,14 @@
 #include "effect.h"
 #include "group.h"
 
+#define LUA_MODULE Effect
+#include "function_array_helper.h"
+
 namespace {
 
 using namespace scriptlib;
 
-int32_t effect_new(lua_State* L) {
+LUA_FUNCTION(CreateEffect) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
@@ -26,7 +29,7 @@ int32_t effect_new(lua_State* L) {
 	interpreter::pushobject(L, peffect);
 	return 1;
 }
-int32_t effect_newex(lua_State* L) {
+LUA_FUNCTION(GlobalEffect) {
 	const auto pduel = lua_get<duel*>(L);
 	effect* peffect = pduel->new_effect();
 	peffect->effect_owner = 0;
@@ -34,13 +37,13 @@ int32_t effect_newex(lua_State* L) {
 	interpreter::pushobject(L, peffect);
 	return 1;
 }
-int32_t effect_clone(lua_State* L) {
+LUA_FUNCTION(Clone) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	interpreter::pushobject(L, peffect->clone());
 	return 1;
 }
-int32_t effect_reset(lua_State* L) {
+LUA_FUNCTION(Reset) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto peffect = lua_get<effect*, true>(L, 1);
@@ -56,31 +59,31 @@ int32_t effect_reset(lua_State* L) {
 	}
 	return 0;
 }
-int32_t effect_get_field_id(lua_State* L) {
+LUA_FUNCTION(GetFieldID) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->id);
 	return 1;
 }
-int32_t effect_set_description(lua_State* L) {
+LUA_FUNCTION(SetDescription) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	peffect->description = lua_get<uint64_t>(L, 2);
 	return 0;
 }
-int32_t effect_set_code(lua_State* L) {
+LUA_FUNCTION(SetCode) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	peffect->code = lua_get<uint32_t>(L, 2);
 	return 0;
 }
-int32_t effect_set_range(lua_State* L) {
+LUA_FUNCTION(SetRange) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	peffect->range = lua_get<uint16_t>(L, 2);
 	return 0;
 }
-int32_t effect_set_target_range(lua_State* L) {
+LUA_FUNCTION(SetTargetRange) {
 	check_param_count(L, 3);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	peffect->s_range = lua_get<uint16_t>(L, 2);
@@ -88,7 +91,7 @@ int32_t effect_set_target_range(lua_State* L) {
 	peffect->flag[0] &= ~EFFECT_FLAG_ABSOLUTE_TARGET;
 	return 0;
 }
-int32_t effect_set_absolute_range(lua_State* L) {
+LUA_FUNCTION(SetAbsoluteRange) {
 	check_param_count(L, 4);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 2);
@@ -104,7 +107,7 @@ int32_t effect_set_absolute_range(lua_State* L) {
 	peffect->flag[0] |= EFFECT_FLAG_ABSOLUTE_TARGET;
 	return 0;
 }
-int32_t effect_set_count_limit(lua_State* L) {
+LUA_FUNCTION(SetCountLimit) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	auto v = lua_get<uint8_t>(L, 2);
@@ -137,7 +140,7 @@ int32_t effect_set_count_limit(lua_State* L) {
 	peffect->count_hopt_index = hopt_index;
 	return 0;
 }
-int32_t effect_set_reset(lua_State* L) {
+LUA_FUNCTION(SetReset) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	auto v = lua_get<uint32_t>(L, 2);
@@ -150,7 +153,7 @@ int32_t effect_set_reset(lua_State* L) {
 	peffect->reset_count = c;
 	return 0;
 }
-int32_t effect_set_type(lua_State* L) {
+LUA_FUNCTION(SetType) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	auto v = lua_get<uint16_t>(L, 2);
@@ -170,7 +173,7 @@ int32_t effect_set_type(lua_State* L) {
 	peffect->type = v;
 	return 0;
 }
-int32_t effect_set_property(lua_State* L) {
+LUA_FUNCTION(SetProperty) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	auto v1 = lua_get<uint32_t>(L, 2);
@@ -179,7 +182,7 @@ int32_t effect_set_property(lua_State* L) {
 	peffect->flag[1] = v2;
 	return 0;
 }
-int32_t effect_set_label(lua_State* L) {
+LUA_FUNCTION(SetLabel) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	peffect->label.clear();
@@ -187,7 +190,7 @@ int32_t effect_set_label(lua_State* L) {
 		peffect->label.push_back(lua_get<lua_Integer>(L, i));
 	return 0;
 }
-int32_t effect_set_label_object(lua_State* L) {
+LUA_FUNCTION(SetLabelObject) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	if(peffect->label_object)
@@ -204,14 +207,14 @@ int32_t effect_set_label_object(lua_State* L) {
 	}
 	return 0;
 }
-int32_t effect_set_category(lua_State* L) {
+LUA_FUNCTION(SetCategory) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	auto v = lua_get<uint32_t>(L, 2);
 	peffect->category = v;
 	return 0;
 }
-int32_t effect_set_hint_timing(lua_State* L) {
+LUA_FUNCTION(SetHintTiming) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	auto vs = lua_get<uint32_t>(L, 2);
@@ -220,7 +223,7 @@ int32_t effect_set_hint_timing(lua_State* L) {
 	peffect->hint_timing[1] = vo;
 	return 0;
 }
-int32_t effect_set_condition(lua_State* L) {
+LUA_FUNCTION(SetCondition) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
@@ -229,7 +232,7 @@ int32_t effect_set_condition(lua_State* L) {
 	peffect->condition = interpreter::get_function_handle(L, 2);
 	return 0;
 }
-int32_t effect_set_target(lua_State* L) {
+LUA_FUNCTION(SetTarget) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
@@ -238,7 +241,7 @@ int32_t effect_set_target(lua_State* L) {
 	peffect->target = interpreter::get_function_handle(L, 2);
 	return 0;
 }
-int32_t effect_set_cost(lua_State* L) {
+LUA_FUNCTION(SetCost) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
@@ -247,7 +250,7 @@ int32_t effect_set_cost(lua_State* L) {
 	peffect->cost = interpreter::get_function_handle(L, 2);
 	return 0;
 }
-int32_t effect_set_value(lua_State* L) {
+LUA_FUNCTION(SetValue) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	if(peffect->value && peffect->is_flag(EFFECT_FLAG_FUNC_VALUE))
@@ -264,7 +267,7 @@ int32_t effect_set_value(lua_State* L) {
 	}
 	return 0;
 }
-int32_t effect_set_operation(lua_State* L) {
+LUA_FUNCTION(SetOperation) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	if(peffect->operation)
@@ -276,7 +279,7 @@ int32_t effect_set_operation(lua_State* L) {
 		peffect->operation = 0;
 	return 0;
 }
-int32_t effect_set_owner_player(lua_State* L) {
+LUA_FUNCTION(SetOwnerPlayer) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	auto p = lua_get<uint8_t>(L, 2);
@@ -285,26 +288,26 @@ int32_t effect_set_owner_player(lua_State* L) {
 	peffect->effect_owner = p;
 	return 0;
 }
-int32_t effect_get_description(lua_State* L) {
+LUA_FUNCTION(GetDescription) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->description);
 	return 1;
 }
-int32_t effect_get_code(lua_State* L) {
+LUA_FUNCTION(GetCode) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->code);
 	return 1;
 }
-int32_t effect_get_target_range(lua_State* L) {
+LUA_FUNCTION(GetTargetRange) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->s_range);
 	lua_pushinteger(L, peffect->o_range);
 	return 2;
 }
-int32_t effect_get_count_limit(lua_State* L) {
+LUA_FUNCTION(GetCountLimit) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->count_limit);
@@ -314,27 +317,27 @@ int32_t effect_get_count_limit(lua_State* L) {
 	lua_pushinteger(L, peffect->count_hopt_index);
 	return 5;
 }
-int32_t effect_get_reset(lua_State* L) {
+LUA_FUNCTION(GetReset) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->reset_flag);
 	lua_pushinteger(L, peffect->reset_count);
 	return 2;
 }
-int32_t effect_get_type(lua_State* L) {
+LUA_FUNCTION(GetType) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->type);
 	return 1;
 }
-int32_t effect_get_property(lua_State* L) {
+LUA_FUNCTION(GetProperty) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->flag[0]);
 	lua_pushinteger(L, peffect->flag[1]);
 	return 2;
 }
-int32_t effect_get_label(lua_State* L) {
+LUA_FUNCTION(GetLabel) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	if(peffect->label.empty()) {
@@ -345,7 +348,7 @@ int32_t effect_get_label(lua_State* L) {
 		lua_pushinteger(L, lab);
 	return peffect->label.size();
 }
-int32_t effect_get_label_object(lua_State* L) {
+LUA_FUNCTION(GetLabelObject) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	if(!peffect->label_object) {
@@ -359,55 +362,55 @@ int32_t effect_get_label_object(lua_State* L) {
 	}
 	return 1;
 }
-int32_t effect_get_category(lua_State* L) {
+LUA_FUNCTION(GetCategory) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->category);
 	return 1;
 }
-int32_t effect_get_owner(lua_State* L) {
+LUA_FUNCTION(GetOwner) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	interpreter::pushobject(L, peffect->owner);
 	return 1;
 }
-int32_t effect_get_handler(lua_State* L) {
+LUA_FUNCTION(GetHandler) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	interpreter::pushobject(L, peffect->get_handler());
 	return 1;
 }
-int32_t effect_get_owner_player(lua_State* L) {
+LUA_FUNCTION(GetOwnerPlayer) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->get_owner_player());
 	return 1;
 }
-int32_t effect_get_handler_player(lua_State* L) {
+LUA_FUNCTION(GetHandlerPlayer) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->get_handler_player());
 	return 1;
 }
-int32_t effect_get_condition(lua_State* L) {
+LUA_FUNCTION(GetCondition) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	interpreter::pushobject(L, peffect->condition);
 	return 1;
 }
-int32_t effect_get_target(lua_State* L) {
+LUA_FUNCTION(GetTarget) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	interpreter::pushobject(L, peffect->target);
 	return 1;
 }
-int32_t effect_get_cost(lua_State* L) {
+LUA_FUNCTION(GetCost) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	interpreter::pushobject(L, peffect->cost);
 	return 1;
 }
-int32_t effect_get_value(lua_State* L) {
+LUA_FUNCTION(GetValue) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	if(peffect->is_flag(EFFECT_FLAG_FUNC_VALUE))
@@ -416,25 +419,25 @@ int32_t effect_get_value(lua_State* L) {
 		lua_pushinteger(L, (int32_t)peffect->value);
 	return 1;
 }
-int32_t effect_get_operation(lua_State* L) {
+LUA_FUNCTION(GetOperation) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	interpreter::pushobject(L, peffect->operation);
 	return 1;
 }
-int32_t effect_get_active_type(lua_State* L) {
+LUA_FUNCTION(GetActiveType) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->get_active_type());
 	return 1;
 }
-int32_t effect_is_active_type(lua_State* L) {
+LUA_FUNCTION(IsActiveType) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushboolean(L, peffect->get_active_type() & lua_get<uint32_t>(L, 2));
 	return 1;
 }
-int32_t effect_is_has_property(lua_State* L) {
+LUA_FUNCTION(IsHasProperty) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	auto tflag1 = lua_get<uint32_t>(L, 2);
@@ -442,19 +445,19 @@ int32_t effect_is_has_property(lua_State* L) {
 	lua_pushboolean(L, ((!tflag1 || (peffect->flag[0] & tflag1)) && (!tflag2 || (peffect->flag[1] & tflag2))));
 	return 1;
 }
-int32_t effect_is_has_category(lua_State* L) {
+LUA_FUNCTION(IsHasCategory) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushboolean(L, peffect->category & lua_get<uint32_t>(L, 2));
 	return 1;
 }
-int32_t effect_is_has_type(lua_State* L) {
+LUA_FUNCTION(IsHasType) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushboolean(L, peffect->type & lua_get<uint16_t>(L, 2));
 	return 1;
 }
-int32_t effect_is_activatable(lua_State* L) {
+LUA_FUNCTION(IsActivatable) {
 	check_param_count(L, 2);
 	const auto pduel = lua_get<duel*>(L);
 	auto peffect = lua_get<effect*, true>(L, 1);
@@ -464,32 +467,32 @@ int32_t effect_is_activatable(lua_State* L) {
 	lua_pushboolean(L, peffect->is_activateable(playerid, pduel->game_field->nil_event, 0, 0, neglect_target, neglect_loc));
 	return 1;
 }
-int32_t effect_is_activated(lua_State* L) {
+LUA_FUNCTION(IsActivated) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushboolean(L, (peffect->type & 0x7f0));
 	return 1;
 }
-int32_t effect_get_activate_location(lua_State* L) {
+LUA_FUNCTION(GetActivateLocation) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->active_location);
 	return 1;
 }
-int32_t effect_get_activate_sequence(lua_State* L) {
+LUA_FUNCTION(GetActivateSequence) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	lua_pushinteger(L, peffect->active_sequence);
 	return 1;
 }
-int32_t effect_check_count_limit(lua_State* L) {
+LUA_FUNCTION(CheckCountLimit) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	auto p = lua_get<uint8_t>(L, 2);
 	lua_pushboolean(L, peffect->check_count_limit(p));
 	return 1;
 }
-int32_t effect_use_count_limit(lua_State* L) {
+LUA_FUNCTION(UseCountLimit) {
 	check_param_count(L, 2);
 	auto peffect = lua_get<effect*, true>(L, 1);
 	auto p = lua_get<uint8_t>(L, 2);
@@ -502,71 +505,15 @@ int32_t effect_use_count_limit(lua_State* L) {
 		}
 	return 0;
 }
-
-static constexpr luaL_Reg effectlib[] = {
-	{ "CreateEffect", effect_new },
-	{ "GlobalEffect", effect_newex },
-	{ "Clone", effect_clone },
-	{ "Reset", effect_reset },
-	{ "GetFieldID", effect_get_field_id },
-	{ "SetDescription", effect_set_description },
-	{ "SetCode", effect_set_code },
-	{ "SetRange", effect_set_range },
-	{ "SetTargetRange", effect_set_target_range },
-	{ "SetAbsoluteRange", effect_set_absolute_range },
-	{ "SetCountLimit", effect_set_count_limit },
-	{ "SetReset", effect_set_reset },
-	{ "SetType", effect_set_type },
-	{ "SetProperty", effect_set_property },
-	{ "SetLabel", effect_set_label },
-	{ "SetLabelObject", effect_set_label_object },
-	{ "SetCategory", effect_set_category },
-	{ "SetHintTiming", effect_set_hint_timing },
-	{ "SetCondition", effect_set_condition },
-	{ "SetTarget", effect_set_target },
-	{ "SetCost", effect_set_cost },
-	{ "SetValue", effect_set_value },
-	{ "SetOperation", effect_set_operation },
-	{ "SetOwnerPlayer", effect_set_owner_player },
-	{ "GetDescription", effect_get_description },
-	{ "GetCode", effect_get_code },
-	{ "GetTargetRange", effect_get_target_range },
-	{ "GetCountLimit", effect_get_count_limit },
-	{ "GetReset", effect_get_reset },
-	{ "GetType", effect_get_type },
-	{ "GetProperty", effect_get_property },
-	{ "GetLabel", effect_get_label },
-	{ "GetLabelObject", effect_get_label_object },
-	{ "GetCategory", effect_get_category },
-	{ "GetOwner", effect_get_owner },
-	{ "GetHandler", effect_get_handler },
-	{ "GetCondition", effect_get_condition },
-	{ "GetTarget", effect_get_target },
-	{ "GetCost", effect_get_cost },
-	{ "GetValue", effect_get_value },
-	{ "GetOperation", effect_get_operation },
-	{ "GetActiveType", effect_get_active_type },
-	{ "IsActiveType", effect_is_active_type },
-	{ "GetOwnerPlayer", effect_get_owner_player },
-	{ "GetHandlerPlayer", effect_get_handler_player },
-	{ "IsHasProperty", effect_is_has_property },
-	{ "IsHasCategory", effect_is_has_category },
-	{ "IsHasType", effect_is_has_type },
-	{ "IsActivatable", effect_is_activatable },
-	{ "IsActivated", effect_is_activated },
-	{ "GetActivateLocation", effect_get_activate_location },
-	{ "GetActivateSequence", effect_get_activate_sequence },
-	{ "CheckCountLimit", effect_check_count_limit },
-	{ "UseCountLimit", effect_use_count_limit },
-	{ "GetLuaRef", get_lua_ref<effect> },
-	{ "FromLuaRef", from_lua_ref<effect> },
-	{ "IsDeleted", is_deleted_object },
-	{ nullptr, nullptr }
-};
+LUA_FUNCTION_EXISTING(GetLuaRef, get_lua_ref<effect>);
+LUA_FUNCTION_EXISTING(FromLuaRef, from_lua_ref<effect>);
+LUA_FUNCTION_EXISTING(IsDeleted, is_deleted_object);
 }
 
 void scriptlib::push_effect_lib(lua_State* L) {
-	luaL_newlib(L, effectlib);
+	static constexpr auto effectlib = GET_LUA_FUNCTIONS_ARRAY();
+	lua_createtable(L, 0, effectlib.size() - 1);
+	luaL_setfuncs(L, effectlib.data(), 0);
 	lua_pushstring(L, "__index");
 	lua_pushvalue(L, -2);
 	lua_rawset(L, -3);

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -848,6 +848,7 @@ LUA_FUNCTION_EXISTING(IsDeleted, is_deleted_object);
 
 void scriptlib::push_group_lib(lua_State* L) {
 	static constexpr auto grouplib = GET_LUA_FUNCTIONS_ARRAY();
+	static_assert(grouplib.back().name == nullptr, "");
 	lua_createtable(L, 0, grouplib.size() - 1);
 	luaL_setfuncs(L, grouplib.data(), 0);
 	lua_pushstring(L, "__index");

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -13,6 +13,9 @@
 #include "effect.h"
 #include "duel.h"
 
+#define LUA_MODULE Group
+#include "function_array_helper.h"
+
 namespace {
 
 using namespace scriptlib;
@@ -24,13 +27,13 @@ void assert_readonly_group(lua_State* L, group* pgroup) {
 	unreachable();
 }
 
-int32_t group_new(lua_State* L) {
+LUA_FUNCTION(CreateGroup) {
 	const auto pduel = lua_get<duel*>(L);
 	group* pgroup = pduel->new_group();
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t group_clone(lua_State* L) {
+LUA_FUNCTION(Clone) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -38,7 +41,7 @@ int32_t group_clone(lua_State* L) {
 	interpreter::pushobject(L, newgroup);
 	return 1;
 }
-int32_t group_from_cards(lua_State* L) {
+LUA_FUNCTION(FromCards) {
 	const auto pduel = lua_get<duel*>(L);
 	group* pgroup = pduel->new_group();
 	for(int32_t i = 0; i < lua_gettop(L); ++i) {
@@ -48,7 +51,7 @@ int32_t group_from_cards(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t group_delete(lua_State* L) {
+LUA_FUNCTION(DeleteGroup) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -58,7 +61,7 @@ int32_t group_delete(lua_State* L) {
 	pduel->sgroups.insert(pgroup);
 	return 0;
 }
-int32_t group_keep_alive(lua_State* L) {
+LUA_FUNCTION(KeepAlive) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -68,7 +71,7 @@ int32_t group_keep_alive(lua_State* L) {
 	pduel->sgroups.erase(pgroup);
 	return 0;
 }
-int32_t group_clear(lua_State* L) {
+LUA_FUNCTION(Clear) {
 	check_param_count(L, 1);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	assert_readonly_group(L, pgroup);
@@ -76,7 +79,7 @@ int32_t group_clear(lua_State* L) {
 	pgroup->container.clear();
 	return 0;
 }
-int32_t group_add_card(lua_State* L) {
+LUA_FUNCTION(AddCard) {
 	check_param_count(L, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	assert_readonly_group(L, pgroup);
@@ -91,7 +94,8 @@ int32_t group_add_card(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t group_remove_card(lua_State* L) {
+LUA_FUNCTION_ALIAS(Merge);
+LUA_FUNCTION(RemoveCard) {
 	check_param_count(L, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	assert_readonly_group(L, pgroup);
@@ -109,7 +113,8 @@ int32_t group_remove_card(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t group_get_next(lua_State* L) {
+LUA_FUNCTION_ALIAS(Sub);
+LUA_FUNCTION(GetNext) {
 	check_param_count(L, 1);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	if(pgroup->is_iterator_dirty) {
@@ -126,7 +131,7 @@ int32_t group_get_next(lua_State* L) {
 	}
 	return 1;
 }
-int32_t group_get_first(lua_State* L) {
+LUA_FUNCTION(GetFirst) {
 	check_param_count(L, 1);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	pgroup->is_iterator_dirty = false;
@@ -136,7 +141,7 @@ int32_t group_get_first(lua_State* L) {
 		lua_pushnil(L);
 	return 1;
 }
-int32_t group_take_at_pos(lua_State* L) {
+LUA_FUNCTION(TakeatPos) {
 	check_param_count(L, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	auto pos = lua_get<size_t>(L, 2);
@@ -149,13 +154,13 @@ int32_t group_take_at_pos(lua_State* L) {
 	}
 	return 1;
 }
-int32_t group_get_count(lua_State* L) {
+LUA_FUNCTION(GetCount) {
 	check_param_count(L, 1);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	lua_pushinteger(L, pgroup->container.size());
 	return 1;
 }
-int32_t group_filter(lua_State* L) {
+LUA_FUNCTION(Filter) {
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -177,7 +182,7 @@ int32_t group_filter(lua_State* L) {
 	interpreter::pushobject(L, new_group);
 	return 1;
 }
-int32_t group_filter_in_place(lua_State* L) {
+LUA_FUNCTION(Match) {
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -216,7 +221,7 @@ int32_t group_filter_in_place(lua_State* L) {
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
-int32_t group_filter_count(lua_State* L) {
+LUA_FUNCTION(FilterCount) {
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -237,7 +242,7 @@ int32_t group_filter_count(lua_State* L) {
 	lua_pushinteger(L, count);
 	return 1;
 }
-int32_t group_filter_select(lua_State* L) {
+LUA_FUNCTION(FilterSelect) {
 	check_action_permission(L);
 	check_param_count(L, 6);
 	check_param(L, PARAM_TYPE_FUNCTION, 3);
@@ -270,7 +275,7 @@ int32_t group_filter_select(lua_State* L) {
 	pduel->game_field->add_process(PROCESSOR_SELECT_CARD, 0, 0, 0, playerid + (cancelable << 16), min + (max << 16));
 	return lua_yieldk(L, 0, (lua_KContext)cancelable, push_return_cards);
 }
-int32_t group_select(lua_State* L) {
+LUA_FUNCTION(Select) {
 	check_action_permission(L);
 	check_param_count(L, 5);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -297,7 +302,7 @@ int32_t group_select(lua_State* L) {
 	pduel->game_field->add_process(PROCESSOR_SELECT_CARD, 0, 0, 0, playerid + (cancelable << 16), min + (max << 16));
 	return lua_yieldk(L, 0, (lua_KContext)cancelable, push_return_cards);
 }
-int32_t group_select_unselect(lua_State* L) {
+LUA_FUNCTION(SelectUnselect) {
 	check_action_permission(L);
 	check_param_count(L, 3);
 	auto pgroup1 = lua_get<group*, true>(L, 1);
@@ -340,7 +345,7 @@ int32_t group_select_unselect(lua_State* L) {
 		return 1;
 	});
 }
-int32_t group_random_select(lua_State* L) {
+LUA_FUNCTION(RandomSelect) {
 	check_param_count(L, 3);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	auto playerid = lua_get<uint8_t>(L, 2);
@@ -372,7 +377,7 @@ int32_t group_random_select(lua_State* L) {
 	interpreter::pushobject(L, newgroup);
 	return 1;
 }
-int32_t group_is_exists(lua_State* L) {
+LUA_FUNCTION(IsExists) {
 	check_param_count(L, 4);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -397,7 +402,7 @@ int32_t group_is_exists(lua_State* L) {
 	lua_pushboolean(L, fcount >= count);
 	return 1;
 }
-int32_t group_check_with_sum_equal(lua_State* L) {
+LUA_FUNCTION(CheckWithSumEqual) {
 	check_param_count(L, 5);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -426,7 +431,7 @@ int32_t group_check_with_sum_equal(lua_State* L) {
 	lua_pushboolean(L, should_continue);
 	return 2;
 }
-int32_t group_select_with_sum_equal(lua_State* L) {
+LUA_FUNCTION(SelectWithSumEqual) {
 	check_action_permission(L);
 	check_param_count(L, 6);
 	check_param(L, PARAM_TYPE_FUNCTION, 3);
@@ -468,7 +473,7 @@ int32_t group_select_with_sum_equal(lua_State* L) {
 		return 1;
 	});
 }
-int32_t group_check_with_sum_greater(lua_State* L) {
+LUA_FUNCTION(CheckWithSumGreater) {
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -491,7 +496,7 @@ int32_t group_check_with_sum_greater(lua_State* L) {
 	lua_pushboolean(L, should_continue);
 	return 2;
 }
-int32_t group_select_with_sum_greater(lua_State* L) {
+LUA_FUNCTION(SelectWithSumGreater) {
 	check_action_permission(L);
 	check_param_count(L, 4);
 	check_param(L, PARAM_TYPE_FUNCTION, 3);
@@ -525,9 +530,9 @@ int32_t group_select_with_sum_greater(lua_State* L) {
 		pduel->game_field->core.must_select_cards.clear();
 		interpreter::pushobject(L, pgroup);
 		return 1;
-					  });
+	});
 }
-int32_t group_get_min_group(lua_State* L) {
+LUA_FUNCTION(GetMinGroup) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -555,7 +560,7 @@ int32_t group_get_min_group(lua_State* L) {
 	lua_pushinteger(L, min);
 	return 2;
 }
-int32_t group_get_max_group(lua_State* L) {
+LUA_FUNCTION(GetMaxGroup) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -583,7 +588,7 @@ int32_t group_get_max_group(lua_State* L) {
 	lua_pushinteger(L, max);
 	return 2;
 }
-int32_t group_get_sum(lua_State* L) {
+LUA_FUNCTION(GetSum) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -596,7 +601,7 @@ int32_t group_get_sum(lua_State* L) {
 	lua_pushinteger(L, sum);
 	return 1;
 }
-int32_t group_get_class(lua_State* L) {
+LUA_FUNCTION(GetClass) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -615,7 +620,7 @@ int32_t group_get_class(lua_State* L) {
 	}
 	return 1;
 }
-int32_t group_get_class_count(lua_State* L) {
+LUA_FUNCTION(GetClassCount) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -628,7 +633,7 @@ int32_t group_get_class_count(lua_State* L) {
 	lua_pushinteger(L, er.size());
 	return 1;
 }
-int32_t group_remove(lua_State* L) {
+LUA_FUNCTION(Remove) {
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -671,7 +676,7 @@ void get_groupcard(lua_State* L, group*& pgroup1, group*& pgroup2, card*& pcard)
 		pgroup2 = static_cast<group*>(obj2);
 	}
 }
-int32_t group_band(lua_State* L) {
+LUA_FUNCTION(__band) {
 	check_param_count(L, 2);
 	group* pgroup1 = nullptr;
 	group* pgroup2 = nullptr;
@@ -690,7 +695,7 @@ int32_t group_band(lua_State* L) {
 	interpreter::pushobject(L, pduel->new_group(std::move(cset)));
 	return 1;
 }
-int32_t group_add(lua_State* L) {
+LUA_FUNCTION(__add) {
 	check_param_count(L, 2);
 	group* pgroup1 = nullptr;
 	group* pgroup2 = nullptr;
@@ -706,7 +711,7 @@ int32_t group_add(lua_State* L) {
 	interpreter::pushobject(L, newgroup);
 	return 1;
 }
-int32_t group_sub_const(lua_State* L) {
+LUA_FUNCTION(__sub) {
 	check_param_count(L, 2);
 	auto pgroup1 = lua_get<group*, true>(L, 1);
 	group* pgroup2 = nullptr;
@@ -723,48 +728,48 @@ int32_t group_sub_const(lua_State* L) {
 	interpreter::pushobject(L, newgroup);
 	return 1;
 }
-int32_t group_len(lua_State* L) {
+LUA_FUNCTION(__len) {
 	check_param_count(L, 1);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	lua_pushinteger(L, pgroup->container.size());
 	return 1;
 }
-int32_t group_equal_size(lua_State* L) {
+LUA_FUNCTION(__eq) {
 	check_param_count(L, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	auto sgroup = lua_get<group*, true>(L, 2);
 	lua_pushboolean(L, pgroup->container.size() == sgroup->container.size());
 	return 1;
 }
-int32_t group_equal(lua_State* L) {
+LUA_FUNCTION(Equal) {
 	check_param_count(L, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	auto sgroup = lua_get<group*, true>(L, 2);
 	lua_pushboolean(L, pgroup->container == sgroup->container);
 	return 1;
 }
-int32_t group_less_than(lua_State* L) {
+LUA_FUNCTION(__lt) {
 	check_param_count(L, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	auto sgroup = lua_get<group*, true>(L, 2);
 	lua_pushboolean(L, pgroup->container.size() < sgroup->container.size());
 	return 1;
 }
-int32_t group_less_equal_than(lua_State* L) {
+LUA_FUNCTION(__le) {
 	check_param_count(L, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
 	auto sgroup = lua_get<group*, true>(L, 2);
 	lua_pushboolean(L, pgroup->container.size() <= sgroup->container.size());
 	return 1;
 }
-int32_t group_is_contains(lua_State* L) {
+LUA_FUNCTION(IsContains) {
 	check_param_count(L, 2);
 	const auto pgroup = lua_get<group*, true>(L, 1);
 	auto pcard = lua_get<card*, true>(L, 2);
 	lua_pushboolean(L, pgroup->has_card(pcard));
 	return 1;
 }
-int32_t group_search_card(lua_State* L) {
+LUA_FUNCTION(SearchCard) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -777,7 +782,7 @@ int32_t group_search_card(lua_State* L) {
 		}
 	return 0;
 }
-int32_t group_split(lua_State* L) {
+LUA_FUNCTION(Split) {
 	check_param_count(L, 3);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -806,7 +811,7 @@ int32_t group_split(lua_State* L) {
 	interpreter::pushobject(L, pduel->new_group(std::move(notmatching)));
 	return 2;
 }
-int32_t group_includes(lua_State* L) {
+LUA_FUNCTION(Includes) {
 	check_param_count(L, 2);
 	auto pgroup1 = lua_get<group*, true>(L, 1);
 	auto pgroup2 = lua_get<group*, true>(L, 2);
@@ -818,7 +823,7 @@ int32_t group_includes(lua_State* L) {
 	lua_pushboolean(L, res);
 	return 1;
 }
-int32_t group_get_bin_class_count(lua_State* L) {
+LUA_FUNCTION(GetBinClassCount) {
 	check_param_count(L, 2);
 	check_param(L, PARAM_TYPE_FUNCTION, 2);
 	auto pgroup = lua_get<group*, true>(L, 1);
@@ -836,61 +841,15 @@ int32_t group_get_bin_class_count(lua_State* L) {
 	lua_pushinteger(L, ans);
 	return 1;
 }
-
-static constexpr luaL_Reg grouplib[] = {
-	{ "__band", group_band },
-	{ "__add", group_add },
-	{ "__sub", group_sub_const },
-	{ "__len", group_len },
-	{ "__eq", group_equal_size },
-	{ "__lt", group_less_than },
-	{ "__le", group_less_equal_than },
-	{ "CreateGroup", group_new },
-	{ "KeepAlive", group_keep_alive },
-	{ "DeleteGroup", group_delete },
-	{ "Clone", group_clone },
-	{ "FromCards", group_from_cards },
-	{ "Clear", group_clear },
-	{ "AddCard", group_add_card },
-	{ "RemoveCard", group_remove_card },
-	{ "Merge", group_add_card },
-	{ "Sub", group_remove_card },
-	{ "GetNext", group_get_next },
-	{ "GetFirst", group_get_first },
-	{ "TakeatPos", group_take_at_pos },
-	{ "GetCount", group_get_count },
-	{ "Filter", group_filter },
-	{ "Match", group_filter_in_place },
-	{ "FilterCount", group_filter_count },
-	{ "FilterSelect", group_filter_select },
-	{ "Select", group_select },
-	{ "SelectUnselect", group_select_unselect },
-	{ "RandomSelect", group_random_select },
-	{ "IsExists", group_is_exists },
-	{ "CheckWithSumEqual", group_check_with_sum_equal },
-	{ "SelectWithSumEqual", group_select_with_sum_equal },
-	{ "CheckWithSumGreater", group_check_with_sum_greater },
-	{ "SelectWithSumGreater", group_select_with_sum_greater },
-	{ "GetMinGroup", group_get_min_group },
-	{ "GetMaxGroup", group_get_max_group },
-	{ "GetSum", group_get_sum },
-	{ "GetClass", group_get_class },
-	{ "GetClassCount", group_get_class_count },
-	{ "Remove", group_remove },
-	{ "Equal", group_equal },
-	{ "IsContains", group_is_contains },
-	{ "SearchCard", group_search_card },
-	{ "Split", group_split },
-	{ "Includes", group_includes },
-	{ "GetLuaRef", get_lua_ref<group> },
-	{ "FromLuaRef", from_lua_ref<group> },
-	{ "IsDeleted", is_deleted_object },
-	{ nullptr, nullptr }
-};
+LUA_FUNCTION_EXISTING(GetLuaRef, get_lua_ref<group>);
+LUA_FUNCTION_EXISTING(FromLuaRef, from_lua_ref<group>);
+LUA_FUNCTION_EXISTING(IsDeleted, is_deleted_object);
 }
 
 void scriptlib::push_group_lib(lua_State* L) {
-	luaL_newlib(L, grouplib);
+	static constexpr auto grouplib = GET_LUA_FUNCTIONS_ARRAY();
+	lua_createtable(L, 0, grouplib.size() - 1);
+	luaL_setfuncs(L, grouplib.data(), 0);
 	lua_pushstring(L, "__index");
 	lua_pushvalue(L, -2);
 	lua_rawset(L, -3);


### PR DESCRIPTION
Use some macro and tepmlate trickery to automatically generate the array of names+function address needed to declare lua libraries from c functions.
This relies on the compiler supporting the ``__COUNTER__`` preprocessor macro.