### PR TITLE
Make get_card_effect also return single trigger effects

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3105,7 +3105,7 @@ void card::get_card_effect(uint32_t code, effect_set* eset) {
 	for (auto rg = single_effect.begin(); rg != single_effect.end();) {
 		peffect = rg->second;
 		++rg;
-		if ((code == 0 || peffect->code == code) && peffect->is_available() && (!peffect->is_flag(EFFECT_FLAG_SINGLE_RANGE) || is_affect_by_effect(peffect)))
+		if ((code == 0 || peffect->code == code) && (!peffect->is_flag(EFFECT_FLAG_SINGLE_RANGE) || is_affect_by_effect(peffect)))
 			eset->push_back(peffect);
 	}
 	for (auto rg = field_effect.begin(); rg != field_effect.end(); ++rg) {


### PR DESCRIPTION
The current state of get_card_effect made it skip single trigger effects because they have the actions type associated. If you have doubts whether this change breaks something, I've tested every card (including unofficial ones) which use get_card_effect, and everything works fine with this change. About 95% of the tested cards pass an effect code to get_card_effect and only care about single effects which aren't triggers, so this change won't affect them. The only card which doesn't pass a code into this function is the divine hierarchy rule card, which filters properly and therefore isn't affected by this change either. I must admit, for now, this change only helps custom cards copy trigger effects, but if it doesn't break stuff, why ignoring this chance altogether.