### PR TITLE
Add Effect.GetHintTiming

### DIFF
--- a/libeffect.cpp
+++ b/libeffect.cpp
@@ -401,6 +401,13 @@ LUA_FUNCTION(GetHandlerPlayer) {
 	lua_pushinteger(L, peffect->get_handler_player());
 	return 1;
 }
+LUA_FUNCTION(GetHintTiming) {
+	check_param_count(L, 1);
+	auto peffect = lua_get<effect*, true>(L, 1);
+	lua_pushinteger(L, peffect->hint_timing[0]);
+	lua_pushinteger(L, peffect->hint_timing[1]);
+	return 2;
+}
 LUA_FUNCTION(GetCondition) {
 	check_param_count(L, 1);
 	auto peffect = lua_get<effect*, true>(L, 1);


### PR DESCRIPTION
Complementary to Effect.SetHintTiming. Retrieves the timings set for the activation of a given effect