### PR TITLE
Fix card::is_removeable 

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3600,6 +3600,8 @@ int32_t card::is_destructable_by_effect(effect* peffect, uint8_t playerid) {
 	return TRUE;
 }
 int32_t card::is_removeable(uint8_t playerid, int32_t pos, uint32_t reason) {
+	if(current.location == LOCATION_REMOVED)
+		return FALSE;
 	if(!pduel->game_field->is_player_can_remove(playerid, this, reason))
 		return FALSE;
 	if(is_affected_by_effect(EFFECT_CANNOT_REMOVE))


### PR DESCRIPTION
The is_removeable method, called by the lua function Card.IsAbleToRemove, does not check if the card is in LOCATION_REMOVED. As as consequence, IsAbleToRemove returns true for a card that is already banished, which is shown in the screenshot below with **Swordsoul Sinister Sovereign - Qixing Longyuan** being able to use its effect when **Swordsoul Blackout** triggers its effect.
This pull requests changes that behavior because, naturally, a card that is already banished cannot be banished.
![image](https://user-images.githubusercontent.com/26061438/209538781-065fb175-4f0a-4059-aa97-f4bd1c47edf1.png)
