### PR TITLE
Fix disable_chain and negate_chain

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -19,21 +19,22 @@ int32_t field::negate_chain(uint8_t chaincount) {
 	if(chaincount > core.current_chain.size() || chaincount < 1)
 		chaincount = static_cast<uint8_t>(core.current_chain.size());
 	chain& pchain = core.current_chain[chaincount - 1];
+	card* effect_handler = pchain.triggering_effect->get_handler();
 	if(!(pchain.flag & CHAIN_DISABLE_ACTIVATE) && is_chain_negatable(pchain.chain_count)
-		&& pchain.triggering_effect->handler->is_affect_by_effect(core.reason_effect)) {
+		&& effect_handler->is_affect_by_effect(core.reason_effect)) {
 		pchain.flag |= CHAIN_DISABLE_ACTIVATE;
 		pchain.disable_reason = core.reason_effect;
 		pchain.disable_player = core.reason_player;
-		if((pchain.triggering_effect->type & EFFECT_TYPE_ACTIVATE) && (pchain.triggering_effect->handler->current.location == LOCATION_SZONE)) {
-			pchain.triggering_effect->handler->set_status(STATUS_LEAVE_CONFIRMED, TRUE);
-			pchain.triggering_effect->handler->set_status(STATUS_ACTIVATE_DISABLED, TRUE);
+		if((pchain.triggering_effect->type & EFFECT_TYPE_ACTIVATE) && (effect_handler->current.location == LOCATION_SZONE)) {
+			effect_handler->set_status(STATUS_LEAVE_CONFIRMED, TRUE);
+			effect_handler->set_status(STATUS_ACTIVATE_DISABLED, TRUE);
 		}
 		auto message = pduel->new_message(MSG_CHAIN_NEGATED);
 		message->write<uint8_t>(chaincount);
 		if(!is_flag(DUEL_RETURN_TO_DECK_TRIGGERS) &&
 		   (pchain.triggering_location == LOCATION_DECK
 			|| (pchain.triggering_location == LOCATION_EXTRA && (pchain.triggering_position & POS_FACEDOWN))))
-			pchain.triggering_effect->handler->release_relation(pchain);
+			effect_handler->release_relation(pchain);
 		return TRUE;
 	}
 	return FALSE;
@@ -44,8 +45,9 @@ int32_t field::disable_chain(uint8_t chaincount) {
 	if(chaincount > core.current_chain.size() || chaincount < 1)
 		chaincount = static_cast<uint8_t>(core.current_chain.size());
 	chain& pchain = core.current_chain[chaincount - 1];
+	card* effect_handler = pchain.triggering_effect->get_handler();
 	if(!(pchain.flag & CHAIN_DISABLE_EFFECT) && is_chain_disablable(pchain.chain_count)
-		&& pchain.triggering_effect->handler->is_affect_by_effect(core.reason_effect)) {
+		&& effect_handler->is_affect_by_effect(core.reason_effect)) {
 		core.current_chain[chaincount - 1].flag |= CHAIN_DISABLE_EFFECT;
 		core.current_chain[chaincount - 1].disable_reason = core.reason_effect;
 		core.current_chain[chaincount - 1].disable_player = core.reason_player;
@@ -54,7 +56,7 @@ int32_t field::disable_chain(uint8_t chaincount) {
 		if(!is_flag(DUEL_RETURN_TO_DECK_TRIGGERS) &&
 		   (pchain.triggering_location == LOCATION_DECK
 		   || (pchain.triggering_location == LOCATION_EXTRA && (pchain.triggering_position & POS_FACEDOWN))))
-			pchain.triggering_effect->handler->release_relation(pchain);
+			effect_handler->release_relation(pchain);
 		return TRUE;
 	}
 	return FALSE;


### PR DESCRIPTION
- Problem: **Expurrely Noir** has 5 or more materials, so it is unaffected by opponent's activated effects. If Noir activates an effect that was provided to it by an Xyz material (via EFFECT_TYPE_XMATERIAL), for example that one of **Purrely Pretty Memory**, **Solemn Strike Strike** is able to negate the activation.
- Correct behavior: Solemn Strike should not be able to negate the activation.
- Solution: change the **Duel.NegateActivation** and **Duel.NegateEffect** functions to check for the appropriate effect handler.

Related ruling, with Tyrant's Temper and a Zoodiac Xyz monster that gained an effect:

> Q.
> 自分フィールドに、「十二獣ラビーナ」をエクシーズ素材としている「十二獣タイグリス」1体と「暴君の威圧」1枚がそれぞれ表側表示で存在しています。
この状況で、その「十二獣タイグリス」を対象として相手が「死者への手向け」を発動し、チェーンして自分がエクシーズ素材となっている「十二獣ラビーナ」の『●このカードを対象とする相手の魔法カードの効果が発動した時、このカードのX素材を１つ取り除いて発動できる。その発動を無効にする』効果を発動した時、さらにチェーンして相手が「天罰」を発動しました。
「暴君の威圧」の効果が適用され「十二獣タイグリス」は罠カードの効果を受けませんが、「天罰」の効果処理はどのようになりますか？
> A.
> ご質問の場合、「十二獣タイグリス」は罠カードの効果を受けませんので、「天罰」の効果処理は何も行われません。
したがって、「死者への手向け」の発動は無効になります。

Example of test puzzle that includes other scenarios, if verification is needed:
```
Debug.ReloadFieldBegin(DUEL_ATTACK_FIRST_TURN,5)
Debug.SetPlayerInfo(0,8000,0,0)
Debug.SetPlayerInfo(1,8000,0,0)

Debug.AddCard(46877100,0,0,LOCATION_MZONE,3,POS_FACEUP_DEFENSE,true)
Debug.AddCard(83827392,0,0,LOCATION_MZONE,0,POS_FACEUP_ATTACK,true)
Debug.AddCard(29599813,0,0,LOCATION_MZONE,0,POS_FACEUP)
Debug.AddCard(25550531,0,0,LOCATION_MZONE,0,POS_FACEUP)
Debug.AddCard(25550531,0,0,LOCATION_MZONE,0,POS_FACEUP)
Debug.AddCard(25550531,0,0,LOCATION_MZONE,0,POS_FACEUP)
Debug.AddCard(25550531,0,0,LOCATION_MZONE,0,POS_FACEUP)
Debug.AddCard(25550531,0,0,LOCATION_MZONE,0,POS_FACEUP)
Debug.AddCard(25550531,0,0,LOCATION_MZONE,0,POS_FACEUP)
Debug.AddCard(25550531,0,0,LOCATION_MZONE,0,POS_FACEUP)
Debug.AddCard(97268402,1,1,LOCATION_HAND,0,POS_FACEUP)
Debug.AddCard(97268402,1,1,LOCATION_HAND,0,POS_FACEUP)
Debug.AddCard(79552283,0,0,LOCATION_SZONE,2,POS_FACEDOWN)
Debug.AddCard(40605147,1,1,LOCATION_SZONE,2,POS_FACEDOWN)
Debug.AddCard(21844576,1,1,LOCATION_MZONE,4,POS_FACEUP_ATTACK,true)
Debug.AddCard(50954680,1,1,LOCATION_MZONE,3,POS_FACEUP_ATTACK,true)

Debug.ReloadFieldEnd()
aux.BeginPuzzle()
```