### PR TITLE
Fix Card.IsAbleToGraveAsCost

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3726,7 +3726,7 @@ int32_t card::is_capable_cost_to_grave(uint8_t playerid) {
 	uint32_t dest = LOCATION_GRAVE;
 	if(data.type & TYPE_TOKEN)
 		return FALSE;
-	if((data.type & TYPE_PENDULUM) && (current.location & LOCATION_ONFIELD) && !is_affected_by_effect(EFFECT_CANNOT_TO_DECK))
+	if((data.type & TYPE_PENDULUM) && (current.location & LOCATION_ONFIELD) && is_capable_send_to_extra(playerid))
 		return FALSE;
 	if(current.location == LOCATION_GRAVE)
 		return FALSE;


### PR DESCRIPTION
Importing https://github.com/Fluorohydride/ygopro-core/commit/775fd42c311e46bd4911b256548b9fc060360b52.

The `is_capable_send_to_extra` function already checks internally by `is_affected_by_effect(EFFECT_CANNOT_TO_DECK)`