### PR TITLE
Update for the handling of position changes via effects

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -5103,27 +5103,29 @@ int32_t field::change_position(uint16_t step, group* targets, effect* reason_eff
 			uint8_t npos = pcard->position_param & 0xff;
 			uint8_t opos = pcard->current.position;
 			if((pcard->current.location != LOCATION_MZONE && pcard->current.location != LOCATION_SZONE)
-				|| ((pcard->data.type & TYPE_LINK) && (pcard->data.type & TYPE_MONSTER))
-				|| pcard->get_status(STATUS_SUMMONING | STATUS_SPSUMMON_STEP)
-				|| (reason_effect && !pcard->is_affect_by_effect(reason_effect)) || npos == opos
-				|| (!(pcard->data.type & TYPE_TOKEN) && (opos & POS_FACEUP) && (npos & POS_FACEDOWN) && !pcard->is_capable_turn_set(reason_player))) {
-					targets->container.erase(pcard);
-					continue;
-				}
+			   || ((pcard->data.type & TYPE_LINK) && (pcard->data.type & TYPE_MONSTER))
+			   || pcard->get_status(STATUS_SUMMONING | STATUS_SPSUMMON_STEP)
+			   || (reason_effect && !pcard->is_affect_by_effect(reason_effect)) || npos == opos
+			   || (!(pcard->data.type & TYPE_TOKEN) && (opos & POS_FACEUP) && (npos & POS_FACEDOWN) && !pcard->is_capable_turn_set(reason_player))) {
+				targets->container.erase(pcard);
+				continue;
+			}
 			//For cards that cannot be changed to an specific position via effects
-			if (reason_effect && pcard->is_affected_by_effect(EFFECT_CANNOT_CHANGE_POS_E)) {
-				effect_set eset;
-				pcard->filter_effect(EFFECT_CANNOT_CHANGE_POS_E, &eset);
-				uint8_t disallowpos = 0;
-				for (const auto& eff : eset)
-					disallowpos = disallowpos | eff->get_value();
-				//If no value is found, no position change is allowed
-				if (!disallowpos)
-					disallowpos = POS_FACEUP|POS_FACEDOWN ;
-				if (npos & disallowpos){
-					targets->container.erase(pcard);
-					continue;
-				}
+			if(!reason_effect)
+				continue;
+			effect_set eset;
+			pcard->filter_effect(EFFECT_CANNOT_CHANGE_POS_E, &eset);
+			if(eset.empty())
+				continue;
+			uint8_t disallowpos = 0;
+			for(const auto& eff : eset)
+				disallowpos |= eff->get_value(reason_effect);
+			//If no value is found, no position change is allowed
+			if(!disallowpos)
+				disallowpos = POS_FACEUP | POS_FACEDOWN;
+			if(npos & disallowpos) {
+				targets->container.erase(pcard);
+				continue;
 			}
 		}
 		card_set* to_grave_set = new card_set;

--- a/operations.cpp
+++ b/operations.cpp
@@ -5119,7 +5119,10 @@ int32_t field::change_position(uint16_t step, group* targets, effect* reason_eff
 				continue;
 			uint8_t disallowpos = 0;
 			for(const auto& eff : eset)
-				disallowpos |= eff->get_value(reason_effect);
+			for(const auto& eff : eset) {
+				auto val = eff->get_value(reason_effect);
+				disallowpos |= val ? val : POS_FACEUP | POS_FACEDOWN;
+			}
 			//If no value is found, no position change is allowed
 			if(!disallowpos)
 				disallowpos = POS_FACEUP | POS_FACEDOWN;

--- a/operations.cpp
+++ b/operations.cpp
@@ -5106,10 +5106,24 @@ int32_t field::change_position(uint16_t step, group* targets, effect* reason_eff
 				|| ((pcard->data.type & TYPE_LINK) && (pcard->data.type & TYPE_MONSTER))
 				|| pcard->get_status(STATUS_SUMMONING | STATUS_SPSUMMON_STEP)
 				|| (reason_effect && !pcard->is_affect_by_effect(reason_effect)) || npos == opos
-				|| (!(pcard->data.type & TYPE_TOKEN) && (opos & POS_FACEUP) && (npos & POS_FACEDOWN) && !pcard->is_capable_turn_set(reason_player))
-				|| (reason_effect && pcard->is_affected_by_effect(EFFECT_CANNOT_CHANGE_POS_E))) {
-				targets->container.erase(pcard);
-				continue;
+				|| (!(pcard->data.type & TYPE_TOKEN) && (opos & POS_FACEUP) && (npos & POS_FACEDOWN) && !pcard->is_capable_turn_set(reason_player))) {
+					targets->container.erase(pcard);
+					continue;
+				}
+			//For cards that cannot be changed to an specific position via effects
+			if (reason_effect && pcard->is_affected_by_effect(EFFECT_CANNOT_CHANGE_POS_E)) {
+				effect_set eset;
+				pcard->filter_effect(EFFECT_CANNOT_CHANGE_POS_E, &eset);
+				uint8_t disallowpos = 0;
+				for (const auto& eff : eset)
+					disallowpos = disallowpos | eff->get_value();
+				//If no value is found, no position change is allowed
+				if (!disallowpos)
+					disallowpos = POS_FACEUP|POS_FACEDOWN ;
+				if (npos & disallowpos){
+					targets->container.erase(pcard);
+					continue;
+				}
 			}
 		}
 		card_set* to_grave_set = new card_set;


### PR DESCRIPTION
Currently, EFFECT_CANNOT_CHANGE_POS_E prevents the affected cards from changing to any position. This changes that behavior to use that effect's value to acquire the positions the card(s) cannot be changed to. If no value is provided, no position change is allowed