### PR TITLE
Fix field::negate_chain

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -25,7 +25,7 @@ int32_t field::negate_chain(uint8_t chaincount) {
 		pchain.flag |= CHAIN_DISABLE_ACTIVATE;
 		pchain.disable_reason = core.reason_effect;
 		pchain.disable_player = core.reason_player;
-		if((pchain.triggering_effect->type & EFFECT_TYPE_ACTIVATE) && (effect_handler->current.location == LOCATION_SZONE)) {
+		if((pchain.triggering_effect->type & EFFECT_TYPE_ACTIVATE) && (effect_handler->is_has_relation(pchain)) && (effect_handler->current.location == LOCATION_SZONE)) {
 			effect_handler->set_status(STATUS_LEAVE_CONFIRMED, TRUE);
 			effect_handler->set_status(STATUS_ACTIVATE_DISABLED, TRUE);
 		}


### PR DESCRIPTION
If a Spell/Trap card that is going to have its activation negated leaves the field but it is put back in the S/T zone before this function (`field::negate_chain`) is executed, it should not be sent to the GY when the negation occurs because it is treated as a different copy of the card. Currently it will be sent to the GY, which is wrong

This pull requests adds an extra check for the chain relation before setting the status to the card