### PR TITLE
Add support for "Ritual Beast Ulti-Reirautari"

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -3654,7 +3654,7 @@ int32_t card::is_releasable_by_summon(uint8_t playerid, card* pcard) {
 		return FALSE;
 	return TRUE;
 }
-int32_t card::is_releasable_by_nonsummon(uint8_t playerid) {
+int32_t card::is_releasable_by_nonsummon(uint8_t playerid, uint32_t reason) {
 	if(is_status(STATUS_SUMMONING))
 		return FALSE;
 	if(overlay_target)
@@ -3663,7 +3663,7 @@ int32_t card::is_releasable_by_nonsummon(uint8_t playerid) {
 		return FALSE;
 	if((current.location == LOCATION_HAND) && (data.type & (TYPE_SPELL | TYPE_TRAP)))
 		return FALSE;
-	if(!pduel->game_field->is_player_can_release(playerid, this))
+	if(!pduel->game_field->is_player_can_release(playerid, this, reason))
 		return FALSE;
 	if(is_affected_by_effect(EFFECT_UNRELEASABLE_NONSUM))
 		return FALSE;

--- a/card.cpp
+++ b/card.cpp
@@ -3646,7 +3646,7 @@ int32_t card::is_releasable_by_summon(uint8_t playerid, card* pcard) {
 		return FALSE;
 	if(current.location & (LOCATION_GRAVE | LOCATION_REMOVED))
 		return FALSE;
-	if(!pduel->game_field->is_player_can_release(playerid, this))
+	if(!pduel->game_field->is_player_can_release(playerid, this, REASON_SUMMON))
 		return FALSE;
 	if(is_affected_by_effect(EFFECT_UNRELEASABLE_SUM, pcard))
 		return FALSE;

--- a/card.h
+++ b/card.h
@@ -336,7 +336,7 @@ public:
 	int32_t is_removeable(uint8_t playerid, uint8_t pos = POS_FACEUP, uint32_t reason = REASON_EFFECT);
 	int32_t is_removeable_as_cost(uint8_t playerid, uint8_t pos = POS_FACEUP);
 	int32_t is_releasable_by_summon(uint8_t playerid, card* pcard);
-	int32_t is_releasable_by_nonsummon(uint8_t playerid, uint32_t reason = 0);
+	int32_t is_releasable_by_nonsummon(uint8_t playerid, uint32_t reason);
 	int32_t is_releasable_by_effect(uint8_t playerid, effect* peffect);
 	int32_t is_capable_send_to_grave(uint8_t playerid);
 	int32_t is_capable_send_to_hand(uint8_t playerid);

--- a/card.h
+++ b/card.h
@@ -336,7 +336,7 @@ public:
 	int32_t is_removeable(uint8_t playerid, uint8_t pos = POS_FACEUP, uint32_t reason = REASON_EFFECT);
 	int32_t is_removeable_as_cost(uint8_t playerid, uint8_t pos = POS_FACEUP);
 	int32_t is_releasable_by_summon(uint8_t playerid, card* pcard);
-	int32_t is_releasable_by_nonsummon(uint8_t playerid, uint32_t reason = REASON_COST);
+	int32_t is_releasable_by_nonsummon(uint8_t playerid, uint32_t reason = 0);
 	int32_t is_releasable_by_effect(uint8_t playerid, effect* peffect);
 	int32_t is_capable_send_to_grave(uint8_t playerid);
 	int32_t is_capable_send_to_hand(uint8_t playerid);

--- a/card.h
+++ b/card.h
@@ -336,7 +336,7 @@ public:
 	int32_t is_removeable(uint8_t playerid, uint8_t pos = POS_FACEUP, uint32_t reason = REASON_EFFECT);
 	int32_t is_removeable_as_cost(uint8_t playerid, uint8_t pos = POS_FACEUP);
 	int32_t is_releasable_by_summon(uint8_t playerid, card* pcard);
-	int32_t is_releasable_by_nonsummon(uint8_t playerid);
+	int32_t is_releasable_by_nonsummon(uint8_t playerid, uint32_t reason = REASON_COST);
 	int32_t is_releasable_by_effect(uint8_t playerid, effect* peffect);
 	int32_t is_capable_send_to_grave(uint8_t playerid);
 	int32_t is_capable_send_to_hand(uint8_t playerid);

--- a/field.cpp
+++ b/field.cpp
@@ -1925,15 +1925,15 @@ void field::get_ritual_material(uint8_t playerid, effect* peffect, card_set* mat
 			&& pcard->is_releasable_by_effect(playerid, peffect);
 	};
 	for(auto& pcard : player[playerid].list_mzone) {
-		if(pcard && mzonecheck(pcard) && pcard->is_releasable_by_nonsummon(playerid))
+		if(pcard && mzonecheck(pcard) && pcard->is_releasable_by_nonsummon(playerid, REASON_EFFECT))
 			material->insert(pcard);
 	}
 	for(auto& pcard : player[1 - playerid].list_mzone) {
-		if(pcard && pcard->is_position(POS_FACEUP) && mzonecheck(pcard) && pcard->is_releasable_by_nonsummon(playerid) && pcard->is_affected_by_effect(EFFECT_EXTRA_RELEASE))
+		if(pcard && pcard->is_position(POS_FACEUP) && mzonecheck(pcard) && pcard->is_releasable_by_nonsummon(playerid, REASON_EFFECT) && pcard->is_affected_by_effect(EFFECT_EXTRA_RELEASE))
 			material->insert(pcard);
 	}
 	for(auto& pcard : player[playerid].list_hand)
-		if((pcard->data.type & TYPE_MONSTER) && pcard->is_releasable_by_nonsummon(playerid))
+		if((pcard->data.type & TYPE_MONSTER) && pcard->is_releasable_by_nonsummon(playerid, REASON_EFFECT))
 			material->insert(pcard);
 	for(auto& pcard : player[playerid].list_grave)
 		if((pcard->data.type & TYPE_MONSTER) && pcard->is_affected_by_effect(EFFECT_EXTRA_RITUAL_MATERIAL) && pcard->is_removeable(playerid, POS_FACEUP, REASON_EFFECT))

--- a/field.cpp
+++ b/field.cpp
@@ -1725,10 +1725,10 @@ void field::get_player_effect(uint8_t playerid, uint32_t code, effect_set* eset)
 			eset->push_back(peffect);
 	}
 }
-int32_t field::get_release_list(uint8_t playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32_t use_hand, int32_t fun, int32_t exarg, card* exc, group* exg, uint8_t use_oppo) {
+int32_t field::get_release_list(uint8_t playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32_t use_hand, int32_t fun, int32_t exarg, card* exc, group* exg, uint8_t use_oppo, uint32_t reason) {
 	uint32_t rcount = 0;
 	for(auto& pcard : player[playerid].list_mzone) {
-		if(pcard && pcard != exc && !(exg && exg->has_card(pcard)) && pcard->is_releasable_by_nonsummon(playerid)
+		if(pcard && pcard != exc && !(exg && exg->has_card(pcard)) && pcard->is_releasable_by_nonsummon(playerid, reason)
 		        && (!fun || pduel->lua->check_matching(pcard, fun, exarg))) {
 			if(release_list)
 				release_list->insert(pcard);
@@ -1738,7 +1738,7 @@ int32_t field::get_release_list(uint8_t playerid, card_set* release_list, card_s
 	}
 	if(use_hand) {
 		for(auto& pcard : player[playerid].list_hand) {
-			if(pcard && pcard != exc && !(exg && exg->has_card(pcard)) && pcard->is_releasable_by_nonsummon(playerid)
+			if(pcard && pcard != exc && !(exg && exg->has_card(pcard)) && pcard->is_releasable_by_nonsummon(playerid, reason)
 			        && (!fun || pduel->lua->check_matching(pcard, fun, exarg))) {
 				if(release_list)
 					release_list->insert(pcard);
@@ -1751,7 +1751,7 @@ int32_t field::get_release_list(uint8_t playerid, card_set* release_list, card_s
 	if(use_oppo) {
 		for(auto& pcard : player[1 - playerid].list_mzone) {
 			if(pcard && pcard != exc && !(exg && exg->has_card(pcard)) && (pcard->is_position(POS_FACEUP) || !fun)
-			   && pcard->is_releasable_by_nonsummon(playerid) && (!fun || pduel->lua->check_matching(pcard, fun, exarg))) {
+			   && pcard->is_releasable_by_nonsummon(playerid, reason) && (!fun || pduel->lua->check_matching(pcard, fun, exarg))) {
 				if(release_list)
 					release_list->insert(pcard);
 				pcard->release_param = 1;
@@ -1761,7 +1761,7 @@ int32_t field::get_release_list(uint8_t playerid, card_set* release_list, card_s
 	} else {
 		for(auto& pcard : player[1 - playerid].list_mzone) {
 			if(pcard && pcard != exc && !(exg && exg->has_card(pcard)) && (pcard->is_position(POS_FACEUP) || !fun)
-			   && pcard->is_releasable_by_nonsummon(playerid) && (!fun || pduel->lua->check_matching(pcard, fun, exarg))) {
+			   && pcard->is_releasable_by_nonsummon(playerid, reason) && (!fun || pduel->lua->check_matching(pcard, fun, exarg))) {
 				pcard->release_param = 1;
 				if(pcard->is_affected_by_effect(EFFECT_EXTRA_RELEASE)) {
 					if(ex_list)
@@ -1785,13 +1785,13 @@ int32_t field::get_release_list(uint8_t playerid, card_set* release_list, card_s
 	}
 	return rcount + ex_oneof_max;
 }
-int32_t field::check_release_list(uint8_t playerid, int32_t min, int32_t /*max*/, int32_t use_hand, int32_t fun, int32_t exarg, card* exc, group* exg, uint8_t check_field, uint8_t to_player, uint8_t zone, card* to_check, uint8_t use_oppo) {
+int32_t field::check_release_list(uint8_t playerid, int32_t min, int32_t /*max*/, int32_t use_hand, int32_t fun, int32_t exarg, card* exc, group* exg, uint8_t check_field, uint8_t to_player, uint8_t zone, card* to_check, uint8_t use_oppo, uint32_t reason) {
 	card_set relcard;
 	//card_set relcard_must;
 	card_set relcard_oneof;
 	bool has_to_choose_one = false;
 	card_set must_choose_one;
-	int32_t rcount = get_release_list(playerid, &relcard, &relcard, &relcard_oneof, use_hand, fun, exarg, exc, exg, use_oppo);
+	int32_t rcount = get_release_list(playerid, &relcard, &relcard, &relcard_oneof, use_hand, fun, exarg, exc, exg, use_oppo, reason);
 	if(check_field) {
 		int32_t ct = 0;
 		zone &= (0x1f & get_forced_zones(to_check, playerid, LOCATION_MZONE, to_player, LOCATION_REASON_TOFIELD));
@@ -2816,7 +2816,8 @@ int32_t field::is_player_can_release(uint8_t playerid, card* pcard, uint32_t rea
 		pduel->lua->add_param<PARAM_TYPE_CARD>(pcard);
 		pduel->lua->add_param<PARAM_TYPE_INT>(playerid);
 		pduel->lua->add_param<PARAM_TYPE_INT>(reason);
-		if (pduel->lua->check_condition(peff->target, 4))
+		pduel->lua->add_param<PARAM_TYPE_EFFECT>(core.reason_effect);
+		if (pduel->lua->check_condition(peff->target, 5))
 			return FALSE;
 	}
 	return TRUE;

--- a/field.cpp
+++ b/field.cpp
@@ -2806,7 +2806,7 @@ int32_t field::is_player_can_spsummon_monster(uint8_t playerid, uint8_t toplayer
 	temp_card->data = {};
 	return result;
 }
-int32_t field::is_player_can_release(uint8_t playerid, card* pcard) {
+int32_t field::is_player_can_release(uint8_t playerid, card* pcard, uint32_t reason) {
 	effect_set eset;
 	filter_player_effect(playerid, EFFECT_CANNOT_RELEASE, &eset);
 	for(const auto& peff : eset) {
@@ -2815,7 +2815,8 @@ int32_t field::is_player_can_release(uint8_t playerid, card* pcard) {
 		pduel->lua->add_param<PARAM_TYPE_EFFECT>(peff);
 		pduel->lua->add_param<PARAM_TYPE_CARD>(pcard);
 		pduel->lua->add_param<PARAM_TYPE_INT>(playerid);
-		if (pduel->lua->check_condition(peff->target, 3))
+		pduel->lua->add_param<PARAM_TYPE_INT>(reason);
+		if (pduel->lua->check_condition(peff->target, 4))
 			return FALSE;
 	}
 	return TRUE;

--- a/field.cpp
+++ b/field.cpp
@@ -1772,7 +1772,7 @@ int32_t field::get_release_list(uint8_t playerid, card_set* release_list, card_s
 					if(!peffect || (peffect->is_flag(EFFECT_FLAG_COUNT_LIMIT) && peffect->count_limit == 0))
 						continue;
 					pduel->lua->add_param<PARAM_TYPE_EFFECT>(core.reason_effect);
-					pduel->lua->add_param<PARAM_TYPE_INT>(REASON_COST);
+					pduel->lua->add_param<PARAM_TYPE_INT>(reason);
 					pduel->lua->add_param<PARAM_TYPE_INT>(core.reason_player);
 					if(!peffect->check_value_condition(3))
 						continue;

--- a/field.h
+++ b/field.h
@@ -537,7 +537,7 @@ public:
 	int32_t is_player_can_flipsummon(uint8_t playerid, card* pcard);
 	int32_t is_player_can_spsummon_monster(uint8_t playerid, uint8_t toplayer, uint8_t sumpos, uint32_t sumtype, card_data* pdata);
 	int32_t is_player_can_spsummon_count(uint8_t playerid, uint32_t count);
-	int32_t is_player_can_release(uint8_t playerid, card* pcard, uint32_t reason = 0);
+	int32_t is_player_can_release(uint8_t playerid, card* pcard, uint32_t reason);
 	int32_t is_player_can_place_counter(uint8_t playerid, card* pcard, uint16_t countertype, uint16_t count);
 	int32_t is_player_can_remove_counter(uint8_t playerid, card* pcard, uint8_t self, uint8_t oppo, uint16_t countertype, uint16_t count, uint32_t reason);
 	int32_t is_player_can_remove_overlay_card(uint8_t playerid, group* pcard, uint8_t self, uint8_t oppo, uint16_t count, uint32_t reason);

--- a/field.h
+++ b/field.h
@@ -480,8 +480,8 @@ public:
 	effect* is_player_affected_by_effect(uint8_t playerid, uint32_t code);
 	void get_player_effect(uint8_t playerid, uint32_t code, effect_set* eset);
 
-	int32_t get_release_list(uint8_t playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32_t use_hand, int32_t fun, int32_t exarg, card* exc, group* exg, uint8_t use_oppo);
-	int32_t check_release_list(uint8_t playerid, int32_t min, int32_t max, int32_t use_hand, int32_t fun, int32_t exarg, card* exc, group* exg, uint8_t check_field, uint8_t to_player, uint8_t zone, card* to_check, uint8_t use_oppo);
+	int32_t get_release_list(uint8_t playerid, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, int32_t use_hand, int32_t fun, int32_t exarg, card* exc, group* exg, uint8_t use_oppo, uint32_t reason);
+	int32_t check_release_list(uint8_t playerid, int32_t min, int32_t max, int32_t use_hand, int32_t fun, int32_t exarg, card* exc, group* exg, uint8_t check_field, uint8_t to_player, uint8_t zone, card* to_check, uint8_t use_oppo, uint32_t reason);
 	int32_t get_summon_release_list(card* target, card_set* release_list, card_set* ex_list, card_set* ex_list_oneof, group* mg = nullptr, uint32_t ex = 0, uint32_t releasable = 0xff00ff, uint32_t pos = 0x1);
 	int32_t get_summon_count_limit(uint8_t playerid);
 	int32_t get_draw_count(uint8_t playerid);

--- a/field.h
+++ b/field.h
@@ -537,7 +537,7 @@ public:
 	int32_t is_player_can_flipsummon(uint8_t playerid, card* pcard);
 	int32_t is_player_can_spsummon_monster(uint8_t playerid, uint8_t toplayer, uint8_t sumpos, uint32_t sumtype, card_data* pdata);
 	int32_t is_player_can_spsummon_count(uint8_t playerid, uint32_t count);
-	int32_t is_player_can_release(uint8_t playerid, card* pcard, uint32_t reason = REASON_COST);
+	int32_t is_player_can_release(uint8_t playerid, card* pcard, uint32_t reason = 0);
 	int32_t is_player_can_place_counter(uint8_t playerid, card* pcard, uint16_t countertype, uint16_t count);
 	int32_t is_player_can_remove_counter(uint8_t playerid, card* pcard, uint8_t self, uint8_t oppo, uint16_t countertype, uint16_t count, uint32_t reason);
 	int32_t is_player_can_remove_overlay_card(uint8_t playerid, group* pcard, uint8_t self, uint8_t oppo, uint16_t count, uint32_t reason);

--- a/field.h
+++ b/field.h
@@ -537,7 +537,7 @@ public:
 	int32_t is_player_can_flipsummon(uint8_t playerid, card* pcard);
 	int32_t is_player_can_spsummon_monster(uint8_t playerid, uint8_t toplayer, uint8_t sumpos, uint32_t sumtype, card_data* pdata);
 	int32_t is_player_can_spsummon_count(uint8_t playerid, uint32_t count);
-	int32_t is_player_can_release(uint8_t playerid, card* pcard);
+	int32_t is_player_can_release(uint8_t playerid, card* pcard, uint32_t reason = REASON_COST);
 	int32_t is_player_can_place_counter(uint8_t playerid, card* pcard, uint16_t countertype, uint16_t count);
 	int32_t is_player_can_remove_counter(uint8_t playerid, card* pcard, uint8_t self, uint8_t oppo, uint16_t countertype, uint16_t count, uint32_t reason);
 	int32_t is_player_can_remove_overlay_card(uint8_t playerid, group* pcard, uint8_t self, uint8_t oppo, uint16_t count, uint32_t reason);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -1879,7 +1879,8 @@ LUA_FUNCTION(IsReleasable) {
 	check_param_count(L, 1);
 	const auto pduel = lua_get<duel*>(L);
 	auto pcard = lua_get<card*, true>(L, 1);
-	lua_pushboolean(L, pcard->is_releasable_by_nonsummon(pduel->game_field->core.reason_player));
+	const auto reason = lua_get<uint32_t, REASON_COST>(L, 2);
+	lua_pushboolean(L, pcard->is_releasable_by_nonsummon(pduel->game_field->core.reason_player, reason));
 	return 1;
 }
 LUA_FUNCTION(IsReleasableByEffect) {
@@ -1888,7 +1889,7 @@ LUA_FUNCTION(IsReleasableByEffect) {
 	auto pcard = lua_get<card*, true>(L, 1);
 	auto p = pduel->game_field->core.reason_player;
 	effect* re = pduel->game_field->core.reason_effect;
-	lua_pushboolean(L, pcard->is_releasable_by_nonsummon(p) && pcard->is_releasable_by_effect(p, re));
+	lua_pushboolean(L, pcard->is_releasable_by_nonsummon(p, REASON_EFFECT) && pcard->is_releasable_by_effect(p, re));
 	return 1;
 }
 LUA_FUNCTION(IsDiscardable) {

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3980,7 +3980,8 @@ LUA_FUNCTION(IsPlayerCanRelease) {
 	else {
 		check_param_count(L, 2);
 		auto pcard = lua_get<card*, true>(L, 2);
-		lua_pushboolean(L, pduel->game_field->is_player_can_release(playerid, pcard));
+		const auto reason = lua_get<uint32_t, REASON_COST>(L, 3);
+		lua_pushboolean(L, pduel->game_field->is_player_can_release(playerid, pcard, reason));
 	}
 	return 1;
 }

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2518,9 +2518,10 @@ LUA_FUNCTION(GetReleaseGroup) {
 		return 0;
 	bool hand = lua_get<bool, false>(L, 2);
 	bool oppo = lua_get<bool, false>(L, 3);
+	const auto reason = lua_get<uint32_t, REASON_COST>(L,4);
 	const auto pduel = lua_get<duel*>(L);
 	group* pgroup = pduel->new_group();
-	pduel->game_field->get_release_list(playerid, &pgroup->container, &pgroup->container, &pgroup->container, hand, 0, 0, 0, 0, oppo);
+	pduel->game_field->get_release_list(playerid, &pgroup->container, &pgroup->container, &pgroup->container, hand, 0, 0, 0, 0, oppo, reason);
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -2536,8 +2537,9 @@ LUA_FUNCTION(GetReleaseGroupCount) {
 		return 0;
 	bool hand = lua_get<bool, false>(L, 2);
 	bool oppo = lua_get<bool, false>(L, 3);
+	const auto reason = lua_get<uint32_t, REASON_COST>(L, 4);
 	const auto pduel = lua_get<duel*>(L);
-	lua_pushinteger(L, pduel->game_field->get_release_list(playerid, 0, 0, 0, hand, 0, 0, 0, 0, oppo));
+	lua_pushinteger(L, pduel->game_field->get_release_list(playerid, 0, 0, 0, hand, 0, 0, 0, 0, oppo, reason));
 	return 1;
 }
 static int32_t check_release_group(lua_State* L, uint8_t use_hand) {
@@ -2557,6 +2559,7 @@ static int32_t check_release_group(lua_State* L, uint8_t use_hand) {
 	card* to_check = nullptr;
 	uint8_t toplayer = playerid;
 	bool use_oppo = false;
+	uint32_t reason = REASON_COST;
 	if(lua_isboolean(L, lastarg)) {
 		use_hand = lua_get<bool>(L, lastarg);
 		++lastarg;
@@ -2572,11 +2575,13 @@ static int32_t check_release_group(lua_State* L, uint8_t use_hand) {
 		++lastarg;
 		use_oppo = lua_get<bool, false>(L, lastarg);
 		++lastarg;
+		reason = lua_get<uint32_t, REASON_COST>(L, lastarg);
+		++lastarg;
 	}
 	if((pexception = lua_get<card*>(L, lastarg)) == nullptr)
 		pexgroup = lua_get<group*>(L, lastarg);
 	uint32_t extraargs = lua_gettop(L) - lastarg;
-	int32_t result = pduel->game_field->check_release_list(playerid, min, max, use_hand, findex, extraargs, pexception, pexgroup, check_field, toplayer, zone, to_check, use_oppo);
+	int32_t result = pduel->game_field->check_release_list(playerid, min, max, use_hand, findex, extraargs, pexception, pexgroup, check_field, toplayer, zone, to_check, use_oppo, reason);
 	pduel->game_field->core.must_select_cards.clear();
 	lua_pushboolean(L, result);
 	return 1;
@@ -2604,6 +2609,7 @@ static int32_t select_release_group(lua_State* L, uint8_t use_hand) {
 	uint8_t toplayer = playerid;
 	uint8_t zone = 0xff;
 	bool use_oppo = false;
+	uint32_t reason = REASON_COST;
 	if(lua_isboolean(L, lastarg)) {
 		use_hand = lua_get<bool>(L, lastarg);
 		++lastarg;
@@ -2619,6 +2625,8 @@ static int32_t select_release_group(lua_State* L, uint8_t use_hand) {
 		++lastarg;
 		use_oppo = lua_get<bool, false>(L, lastarg);
 		++lastarg;
+		reason = lua_get<uint32_t, REASON_COST>(L, lastarg);
+		++lastarg;
 	}
 	if((pexception = lua_get<card*>(L, lastarg)) == nullptr)
 		pexgroup = lua_get<group*>(L, lastarg);
@@ -2629,7 +2637,7 @@ static int32_t select_release_group(lua_State* L, uint8_t use_hand) {
 	pduel->game_field->core.release_cards.clear();
 	pduel->game_field->core.release_cards_ex.clear();
 	pduel->game_field->core.release_cards_ex_oneof.clear();
-	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_hand, findex, extraargs, pexception, pexgroup, use_oppo);
+	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_hand, findex, extraargs, pexception, pexgroup, use_oppo, reason);
 	pduel->game_field->add_process(PROCESSOR_SELECT_RELEASE, 0, 0, (group*)to_check, playerid + (cancelable << 16), (max << 16) + min, check_field + (toplayer << 8) + (zone << 16));
 	return lua_yieldk(L, 0, (lua_KContext)cancelable, push_return_cards);
 }

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2559,7 +2559,6 @@ static int32_t check_release_group(lua_State* L, uint8_t use_hand) {
 	card* to_check = nullptr;
 	uint8_t toplayer = playerid;
 	bool use_oppo = false;
-	uint32_t reason = REASON_COST;
 	if(lua_isboolean(L, lastarg)) {
 		use_hand = lua_get<bool>(L, lastarg);
 		++lastarg;
@@ -2575,13 +2574,11 @@ static int32_t check_release_group(lua_State* L, uint8_t use_hand) {
 		++lastarg;
 		use_oppo = lua_get<bool, false>(L, lastarg);
 		++lastarg;
-		reason = lua_get<uint32_t, REASON_COST>(L, lastarg);
-		++lastarg;
 	}
 	if((pexception = lua_get<card*>(L, lastarg)) == nullptr)
 		pexgroup = lua_get<group*>(L, lastarg);
 	uint32_t extraargs = lua_gettop(L) - lastarg;
-	int32_t result = pduel->game_field->check_release_list(playerid, min, max, use_hand, findex, extraargs, pexception, pexgroup, check_field, toplayer, zone, to_check, use_oppo, reason);
+	int32_t result = pduel->game_field->check_release_list(playerid, min, max, use_hand, findex, extraargs, pexception, pexgroup, check_field, toplayer, zone, to_check, use_oppo, REASON_EFFECT);
 	pduel->game_field->core.must_select_cards.clear();
 	lua_pushboolean(L, result);
 	return 1;
@@ -2609,7 +2606,6 @@ static int32_t select_release_group(lua_State* L, uint8_t use_hand) {
 	uint8_t toplayer = playerid;
 	uint8_t zone = 0xff;
 	bool use_oppo = false;
-	uint32_t reason = REASON_COST;
 	if(lua_isboolean(L, lastarg)) {
 		use_hand = lua_get<bool>(L, lastarg);
 		++lastarg;
@@ -2625,8 +2621,6 @@ static int32_t select_release_group(lua_State* L, uint8_t use_hand) {
 		++lastarg;
 		use_oppo = lua_get<bool, false>(L, lastarg);
 		++lastarg;
-		reason = lua_get<uint32_t, REASON_COST>(L, lastarg);
-		++lastarg;
 	}
 	if((pexception = lua_get<card*>(L, lastarg)) == nullptr)
 		pexgroup = lua_get<group*>(L, lastarg);
@@ -2637,7 +2631,7 @@ static int32_t select_release_group(lua_State* L, uint8_t use_hand) {
 	pduel->game_field->core.release_cards.clear();
 	pduel->game_field->core.release_cards_ex.clear();
 	pduel->game_field->core.release_cards_ex_oneof.clear();
-	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_hand, findex, extraargs, pexception, pexgroup, use_oppo, reason);
+	pduel->game_field->get_release_list(playerid, &pduel->game_field->core.release_cards, &pduel->game_field->core.release_cards_ex, &pduel->game_field->core.release_cards_ex_oneof, use_hand, findex, extraargs, pexception, pexgroup, use_oppo, REASON_EFFECT);
 	pduel->game_field->add_process(PROCESSOR_SELECT_RELEASE, 0, 0, (group*)to_check, playerid + (cancelable << 16), (max << 16) + min, check_field + (toplayer << 8) + (zone << 16));
 	return lua_yieldk(L, 0, (lua_KContext)cancelable, push_return_cards);
 }

--- a/operations.cpp
+++ b/operations.cpp
@@ -4113,7 +4113,7 @@ int32_t field::release(uint16_t step, group* targets, effect* reason_effect, uin
 			if(pcard->get_status(STATUS_SUMMONING | STATUS_SPSUMMON_STEP)
 				|| ((reason & REASON_SUMMON) && !pcard->is_releasable_by_summon(reason_player, pcard->current.reason_card))
 				|| (!(pcard->current.reason & (REASON_RULE | REASON_SUMMON | REASON_COST))
-					&& (!pcard->is_affect_by_effect(pcard->current.reason_effect) || !pcard->is_releasable_by_nonsummon(reason_player)))) {
+					&& (!pcard->is_affect_by_effect(pcard->current.reason_effect) || !pcard->is_releasable_by_nonsummon(reason_player, reason)))) {
 				pcard->current.reason = pcard->temp.reason;
 				pcard->current.reason_effect = pcard->temp.reason_effect;
 				pcard->current.reason_player = pcard->temp.reason_player;


### PR DESCRIPTION
* Update Card.IsReleasable to accept a second, optional parameter for the reason. Defaulting it to REASON_COST will prevent massive script changes (cards that tribute by effect already use Card.IsReleasableByEffect).

* Update EFFECT_CANNOT_RELEASE to pass a 4th parameter, the reason, to its target so it can be used in cards that implement such effect

* Update the relevant the internal usage of card::is_releasable_by_nonsummon and field::is_player_can_release to reflect the aforementioned changes