### PR TITLE
Addressed implementation defined behaviour in rng function

### DIFF
--- a/duel.cpp
+++ b/duel.cpp
@@ -132,13 +132,14 @@ void duel::set_response(const void* resp, size_t len) {
 }
 // uniform integer distribution
 int32_t duel::get_next_integer(int32_t l, int32_t h) {
-	const uint32_t range = h - l + 1;
-	const uint32_t lim = random.max() % range;
+	assert(l <= h);
+	const uint64_t range = int64_t(h) - int64_t(l) + 1;
+	const uint64_t lim = random.max() % range;
 	uint64_t n;
 	do {
 		n = random();
 	} while(n <= lim);
-	return static_cast<int32_t>(n % range) + l;
+	return static_cast<int32_t>((n % range) + l);
 }
 duel::duel_message* duel::new_message(uint8_t message) {
 	return &(messages.emplace_back(message));

--- a/duel.cpp
+++ b/duel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010-2015, Argon Sun (Fluorohydride)
- * Copyright (c) 2017-2024, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
+ * Copyright (c) 2017-2025, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -132,13 +132,13 @@ void duel::set_response(const void* resp, size_t len) {
 }
 // uniform integer distribution
 int32_t duel::get_next_integer(int32_t l, int32_t h) {
-	const int32_t range = h - l + 1;
-	const int32_t lim = random.max() % range;
-	int32_t n;
+	const uint32_t range = h - l + 1;
+	const uint32_t lim = random.max() % range;
+	uint32_t n;
 	do {
-		n = random();
+		n = static_cast<uint32_t>(random());
 	} while(n <= lim);
-	return static_cast<int32_t>((n % range) + l);
+	return static_cast<int32_t>(n % range) + l;
 }
 duel::duel_message* duel::new_message(uint8_t message) {
 	return &(messages.emplace_back(message));

--- a/duel.cpp
+++ b/duel.cpp
@@ -134,9 +134,9 @@ void duel::set_response(const void* resp, size_t len) {
 int32_t duel::get_next_integer(int32_t l, int32_t h) {
 	const uint32_t range = h - l + 1;
 	const uint32_t lim = random.max() % range;
-	uint32_t n;
+	uint64_t n;
 	do {
-		n = static_cast<uint32_t>(random());
+		n = random();
 	} while(n <= lim);
 	return static_cast<int32_t>(n % range) + l;
 }


### PR DESCRIPTION
Properly handle the results of the rng output as unsigned ints, rather than relying on implementation defined conversion from unsigned to signed integers, breaking change