### PR TITLE
Update effect damage evaluation

### DIFF
--- a/operations.cpp
+++ b/operations.cpp
@@ -587,7 +587,7 @@ bool field::process(Processors::Damage& arg) {
 				6: damage becomes 0.
 				7: damage is halved.
 				8: damage is doubled.
-				9: damage becomes X (X being a predetermined value).
+				9: damage becomes X (X being a predetermined value). Lowest value is applied.
 				However, if the Damage has become 0 when applying "6" effects, the remaining effects are not applied.
 			*/
 			if (temp_damage_value == 0) {
@@ -603,7 +603,7 @@ bool field::process(Processors::Damage& arg) {
 					// If it is not cases 6, 7 or 8, it is 9:
 					fixed_damage_counter++;
 				}
-				//Update "damage becomes X" when there are multiples to keep the lowest value:
+				// Update "damage becomes X" when there are multiples to keep the lowest value:
 				if (fixed_damage_counter > 1)
 					fixed_damage_value = std::min(fixed_damage_value, temp_damage_value);
 				else
@@ -621,7 +621,7 @@ bool field::process(Processors::Damage& arg) {
 				val *= 2;
 			if (half_damage)
 				val /= 2;
-			// Apply "damage becomes X " last:
+			// Apply "damage becomes X" last:
 			if (fixed_damage_counter)
 				val = fixed_damage_value;
 		}

--- a/operations.cpp
+++ b/operations.cpp
@@ -617,10 +617,10 @@ bool field::process(Processors::Damage& arg) {
 				half_damage = false;
 			}
 			// Apply one instance of double or half damage (they do not stack):
-			if (double_damage)
-				val *= 2;
 			if (half_damage)
 				val /= 2;
+			if (double_damage)
+				val *= 2;
 			// Apply "damage becomes X" last:
 			if (fixed_damage_counter)
 				val = fixed_damage_value;


### PR DESCRIPTION
Currently, EFFECT_CHANGE_DAMAGE will apply all those effects to the damage value in sequence, which leads to multiple double or half **effect damage** being able to be stacked.
Attempt to fix the evaluation of effect damage, implementing the following rules extrapolated from the battle damage calculation:
- If multiple effects change how damage is calculated, they are applied in the following order:
  - 6: damage becomes 0.
  - 7: damage is halved.
  - 8: damage is doubled.
  - 9: damage becomes X (X being a predetermined value). 
- However, if the Damage has become 0 when applying "6" effects, the remaining effects are not applied.

For category (9), there is no card that sets effect damage to a value that is not 0, double or half, but we use the rulings found for the equivalent with battle damage, which say that the lowest value is applied. Source: [Submarineroid's page](https://yugioh-wiki.net/index.php?%A1%D4%A5%B5%A5%D6%A5%DE%A5%EA%A5%F3%A5%ED%A5%A4%A5%C9%A1%D5)