### PR TITLE
Add Support for card requester parameter in code modification effects

### DIFF
--- a/card.cpp
+++ b/card.cpp
@@ -293,7 +293,7 @@ void card::get_summon_code(std::set<uint32_t>& codes, card* scard, uint64_t sumt
 		pduel->lua->add_param<LuaParam::INT>(sumtype);
 		pduel->lua->add_param<LuaParam::INT>(playerid);
 		pduel->lua->add_param<LuaParam::CARD>(reqcard);
-		if (!pduel->lua->check_condition(peffect->operation, 3))
+		if (!pduel->lua->check_condition(peffect->operation, 4))
 			continue;
 		if (peffect->code == EFFECT_ADD_CODE)
 			codes.insert(peffect->get_value(this));
@@ -379,7 +379,7 @@ int32_t card::is_summon_set_card(uint16_t set_code, card* scard, uint64_t sumtyp
 		pduel->lua->add_param<LuaParam::INT>(sumtype);
 		pduel->lua->add_param<LuaParam::INT>(playerid);
 		pduel->lua->add_param<LuaParam::CARD>(reqcard);
-		if (!pduel->lua->check_condition(peffect->operation, 3))
+		if (!pduel->lua->check_condition(peffect->operation, 4))
 			continue;
 		if (peffect->code== EFFECT_ADD_CODE)
 			codes.insert(peffect->get_value(this));
@@ -469,7 +469,7 @@ void card::get_summon_set_card(std::set<uint16_t>& setcodes, card* scard, uint64
 		pduel->lua->add_param<LuaParam::INT>(sumtype);
 		pduel->lua->add_param<LuaParam::INT>(playerid);
 		pduel->lua->add_param<LuaParam::CARD>(reqcard);
-		if (!pduel->lua->check_condition(peffect->operation, 3))
+		if (!pduel->lua->check_condition(peffect->operation, 4))
 			continue;
 		if (peffect->code == EFFECT_ADD_CODE)
 			codes.insert(peffect->get_value(this));

--- a/card.cpp
+++ b/card.cpp
@@ -280,7 +280,7 @@ uint32_t card::get_another_code() {
 		return otcode;
 	return 0;
 }
-void card::get_summon_code(std::set<uint32_t>& codes, card* scard, uint64_t sumtype, uint8_t playerid) {
+void card::get_summon_code(std::set<uint32_t>& codes, card* scard, uint64_t sumtype, uint8_t playerid, card* reqcard) {
 	effect_set eset;
 	bool changed = false;
 	filter_effect(EFFECT_ADD_CODE, &eset, FALSE);
@@ -292,6 +292,7 @@ void card::get_summon_code(std::set<uint32_t>& codes, card* scard, uint64_t sumt
 		pduel->lua->add_param<LuaParam::CARD>(scard);
 		pduel->lua->add_param<LuaParam::INT>(sumtype);
 		pduel->lua->add_param<LuaParam::INT>(playerid);
+		pduel->lua->add_param<LuaParam::CARD>(reqcard);
 		if (!pduel->lua->check_condition(peffect->operation, 3))
 			continue;
 		if (peffect->code == EFFECT_ADD_CODE)
@@ -364,7 +365,7 @@ int32_t card::is_pre_set_card(uint16_t set_code) {
 	}
 	return FALSE;
 }
-int32_t card::is_summon_set_card(uint16_t set_code, card* scard, uint64_t sumtype, uint8_t playerid) {
+int32_t card::is_summon_set_card(uint16_t set_code, card* scard, uint64_t sumtype, uint8_t playerid, card* reqcard) {
 	effect_set eset;
 	std::set<uint32_t> codes;
 	bool changed = false;
@@ -377,6 +378,7 @@ int32_t card::is_summon_set_card(uint16_t set_code, card* scard, uint64_t sumtyp
 		pduel->lua->add_param<LuaParam::CARD>(scard);
 		pduel->lua->add_param<LuaParam::INT>(sumtype);
 		pduel->lua->add_param<LuaParam::INT>(playerid);
+		pduel->lua->add_param<LuaParam::CARD>(reqcard);
 		if (!pduel->lua->check_condition(peffect->operation, 3))
 			continue;
 		if (peffect->code== EFFECT_ADD_CODE)
@@ -453,7 +455,7 @@ void card::get_pre_set_card(std::set<uint16_t>& setcodes) {
 		setcodes.insert(other_setcodes.begin(), other_setcodes.end());
 	}
 }
-void card::get_summon_set_card(std::set<uint16_t>& setcodes, card* scard, uint64_t sumtype, uint8_t playerid) {
+void card::get_summon_set_card(std::set<uint16_t>& setcodes, card* scard, uint64_t sumtype, uint8_t playerid, card* reqcard) {
 	effect_set eset;
 	std::set<uint32_t> codes;
 	bool changed = false;
@@ -466,6 +468,7 @@ void card::get_summon_set_card(std::set<uint16_t>& setcodes, card* scard, uint64
 		pduel->lua->add_param<LuaParam::CARD>(scard);
 		pduel->lua->add_param<LuaParam::INT>(sumtype);
 		pduel->lua->add_param<LuaParam::INT>(playerid);
+		pduel->lua->add_param<LuaParam::CARD>(reqcard);
 		if (!pduel->lua->check_condition(peffect->operation, 3))
 			continue;
 		if (peffect->code == EFFECT_ADD_CODE)

--- a/card.h
+++ b/card.h
@@ -200,15 +200,15 @@ public:
 	uint32_t second_code(uint32_t code);
 	uint32_t get_code();
 	uint32_t get_another_code();
-	void get_summon_code(std::set<uint32_t>& codes, card* scard = nullptr, uint64_t sumtype = 0, uint8_t playerid = 2);
+	void get_summon_code(std::set<uint32_t>& codes, card* scard = nullptr, uint64_t sumtype = 0, uint8_t playerid = 2, card* reqcard = nullptr);
 	int32_t is_set_card(uint16_t set_code);
 	int32_t is_origin_set_card(uint16_t set_code);
 	int32_t is_pre_set_card(uint16_t set_code);
-	int32_t is_summon_set_card(uint16_t set_code, card* scard = nullptr, uint64_t sumtype = 0, uint8_t playerid = 2);
+	int32_t is_summon_set_card(uint16_t set_code, card* scard = nullptr, uint64_t sumtype = 0, uint8_t playerid = 2, card* reqcard = nullptr);
 	void get_set_card(std::set<uint16_t>& setcodes);
 	const std::set<uint16_t>& get_origin_set_card() const { return data.setcodes; }
 	void get_pre_set_card(std::set<uint16_t>& setcodes);
-	void get_summon_set_card(std::set<uint16_t>& setcodes, card* scard = nullptr, uint64_t sumtype = 0, uint8_t playerid = 2);
+	void get_summon_set_card(std::set<uint16_t>& setcodes, card* scard = nullptr, uint64_t sumtype = 0, uint8_t playerid = 2, card* reqcard = nullptr);
 	uint32_t get_type(card* scard = nullptr, uint64_t sumtype = 0, uint8_t playerid = 2);
 	int32_t get_base_attack();
 	int32_t get_attack();

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -607,7 +607,7 @@ LUA_FUNCTION(IsSummonCode) {
 	if (!lua_isnoneornil(L, 5)) {
 		if (check_param<LuaParam::CARD, true>(L, 5)) {
 			stack_index++;
-			scard = lua_get<card*, true>(L, 5);
+			reqcard = lua_get<card*, true>(L, 5);
 		}
 	}
 	effect_set eset;

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -627,7 +627,7 @@ LUA_FUNCTION(IsSummonCode) {
 		pduel->lua->add_param<LuaParam::INT>(sumtype);
 		pduel->lua->add_param<LuaParam::INT>(playerid);
 		pduel->lua->add_param<LuaParam::CARD>(reqcard);
-		if (!pduel->lua->check_condition(peff->operation, 3))
+		if (!pduel->lua->check_condition(peff->operation, 4))
 			continue;
 		if (peff->code == EFFECT_ADD_CODE)
 			codes.insert(peff->get_value(self));


### PR DESCRIPTION
The following effects now accept an additional parameter to specify the card requesting the code change, if needed. This update enables support for effects like [Variable Stellarizer](https://yugipedia.com/wiki/Variable_Stellarizer):
- EFFECT_ADD_CODE
- EFFECT_REMOVE_CODE
- EFFECT_CHANGE_CODE 