### PR TITLE
Move groups lifetime management to lua

### DIFF
--- a/duel.cpp
+++ b/duel.cpp
@@ -101,6 +101,7 @@ void duel::generate_buffer() {
 	messages.clear();
 }
 void duel::release_script_group() {
+	lua->collect();
 }
 void duel::restore_assumes() {
 	for(auto& pcard : assumes)

--- a/duel.cpp
+++ b/duel.cpp
@@ -89,7 +89,7 @@ void duel::delete_card(card* pcard) {
 	cards.erase(pcard);
 	delete pcard;
 }
-void duel::delete_group_no_unref(group* pgroup) {
+void duel::delete_group(group* pgroup) {
 	groups.erase(pgroup);
 	delete pgroup;
 }

--- a/duel.cpp
+++ b/duel.cpp
@@ -108,8 +108,6 @@ void duel::generate_buffer() {
 	}
 	messages.clear();
 }
-void duel::release_script_group() {
-}
 void duel::restore_assumes() {
 	for(auto& pcard : assumes)
 		pcard->assume.clear();

--- a/duel.cpp
+++ b/duel.cpp
@@ -80,8 +80,9 @@ void duel::delete_card(card* pcard) {
 }
 void duel::delete_group(group* pgroup) {
 	lua->unregister_group(pgroup);
+}
+void duel::delete_group_no_unref(group* pgroup) {
 	groups.erase(pgroup);
-	sgroups.erase(pgroup);
 	delete pgroup;
 }
 void duel::delete_effect(effect* peffect) {
@@ -100,14 +101,6 @@ void duel::generate_buffer() {
 	messages.clear();
 }
 void duel::release_script_group() {
-	for(auto& pgroup : sgroups) {
-		if(pgroup->is_readonly == 0) {
-			lua->unregister_group(pgroup);
-			groups.erase(pgroup);
-			delete pgroup;
-		}
-	}
-	sgroups.clear();
 }
 void duel::restore_assumes() {
 	for(auto& pcard : assumes)

--- a/duel.cpp
+++ b/duel.cpp
@@ -51,8 +51,8 @@ void duel::clear() {
 		delete peffect;
 	}
 	delete game_field;
-	//force garbage collection to clean the groups
-	lua->collect();
+	//force full garbage collection to clean the groups
+	lua->collect(true);
 	cards.clear();
 	/*
 		TODO: how to properly handle groups that are still around after the field was destroyed?

--- a/duel.cpp
+++ b/duel.cpp
@@ -120,7 +120,6 @@ void duel::generate_buffer() {
 	messages.clear();
 }
 void duel::release_script_group() {
-	lua->collect();
 }
 void duel::restore_assumes() {
 	for(auto& pcard : assumes)

--- a/duel.cpp
+++ b/duel.cpp
@@ -27,11 +27,9 @@ duel::~duel() {
 	for(auto& pcard : cards)
 		delete pcard;
 	//NOTE: unregister_group could trigger garbage collection, altering the groups set
-	auto groups_copy = groups;
-	for(auto& pgroup : groups_copy) {
+	for(auto& pgroup : groups) {
 		pgroup->container.clear();
 		pgroup->is_iterator_dirty = true;
-		lua->unregister_group(pgroup);
 	}
 	for(auto& peffect : effects)
 		delete peffect;
@@ -49,11 +47,6 @@ void duel::clear() {
 	static constexpr OCG_DuelOptions default_options{ {},0,{8000,5,1},{8000,5,1} };
 	for(auto& pcard : cards)
 		delete pcard;
-	//NOTE: unregister_group could trigger garbage collection, altering the groups set
-	auto groups_copy = groups;
-	for(auto& pgroup : groups_copy) {
-		lua->unregister_group(pgroup);
-	}
 	for(auto& peffect : effects) {
 		lua->unregister_effect(peffect);
 		delete peffect;
@@ -96,9 +89,6 @@ effect* duel::new_effect() {
 void duel::delete_card(card* pcard) {
 	cards.erase(pcard);
 	delete pcard;
-}
-void duel::delete_group(group* pgroup) {
-	lua->unregister_group(pgroup);
 }
 void duel::delete_group_no_unref(group* pgroup) {
 	groups.erase(pgroup);

--- a/duel.cpp
+++ b/duel.cpp
@@ -26,12 +26,20 @@ duel::duel(const OCG_DuelOptions& options) :
 duel::~duel() {
 	for(auto& pcard : cards)
 		delete pcard;
-	for(auto& pgroup : groups)
-		delete pgroup;
+	//NOTE: unregister_group could trigger garbage collection, altering the groups set
+	auto groups_copy = groups;
+	for(auto& pgroup : groups_copy) {
+		pgroup->container.clear();
+		pgroup->is_iterator_dirty = true;
+		lua->unregister_group(pgroup);
+	}
 	for(auto& peffect : effects)
 		delete peffect;
 	delete game_field;
 	delete lua;
+	// TODO: this should actually be an assertion as no group should outlive the lua state
+	for(auto& pgroup : groups)
+		delete pgroup;
 }
 #if defined(__GNUC__) || defined(__clang_analyzer__)
 #pragma GCC diagnostic push
@@ -41,17 +49,28 @@ void duel::clear() {
 	static constexpr OCG_DuelOptions default_options{ {},0,{8000,5,1},{8000,5,1} };
 	for(auto& pcard : cards)
 		delete pcard;
-	for(auto& pgroup : groups) {
+	//NOTE: unregister_group could trigger garbage collection, altering the groups set
+	auto groups_copy = groups;
+	for(auto& pgroup : groups_copy) {
 		lua->unregister_group(pgroup);
-		delete pgroup;
 	}
 	for(auto& peffect : effects) {
 		lua->unregister_effect(peffect);
 		delete peffect;
 	}
 	delete game_field;
+	//force garbage collection to clean the groups
+	lua->collect();
 	cards.clear();
-	groups.clear();
+	/*
+	 * TODO: how to properly handle groups that are still around after the field was destroyed ?
+	 * If they're still here, it means they're still living as global variables somewhere, for now we
+	 * deal with them by clearing their containers that could have been pointing to now deleted cards
+	*/
+	for(auto& pgroup : groups) {
+		pgroup->container.clear();
+		pgroup->is_iterator_dirty = true;
+	}
 	effects.clear();
 	game_field = new field(this, default_options);
 	game_field->temp_card = new_card(0);

--- a/duel.cpp
+++ b/duel.cpp
@@ -26,7 +26,6 @@ duel::duel(const OCG_DuelOptions& options) :
 duel::~duel() {
 	for(auto& pcard : cards)
 		delete pcard;
-	//NOTE: unregister_group could trigger garbage collection, altering the groups set
 	for(auto& pgroup : groups) {
 		pgroup->container.clear();
 		pgroup->is_iterator_dirty = true;
@@ -56,9 +55,9 @@ void duel::clear() {
 	lua->collect();
 	cards.clear();
 	/*
-	 * TODO: how to properly handle groups that are still around after the field was destroyed ?
-	 * If they're still here, it means they're still living as global variables somewhere, for now we
-	 * deal with them by clearing their containers that could have been pointing to now deleted cards
+		TODO: how to properly handle groups that are still around after the field was destroyed?
+		If they're still here, it means they're still living as global variables somewhere, for now we
+		deal with them by clearing their containers that could have been pointing to now deleted cards
 	*/
 	for(auto& pgroup : groups) {
 		pgroup->container.clear();

--- a/duel.h
+++ b/duel.h
@@ -102,7 +102,7 @@ public:
 	}
 	effect* new_effect();
 	void delete_card(card* pcard);
-	void delete_group_no_unref(group* pgroup);
+	void delete_group(group* pgroup);
 	void delete_effect(effect* peffect);
 	void release_script_group();
 	void restore_assumes();

--- a/duel.h
+++ b/duel.h
@@ -104,7 +104,6 @@ public:
 	void delete_card(card* pcard);
 	void delete_group(group* pgroup);
 	void delete_effect(effect* peffect);
-	void release_script_group();
 	void restore_assumes();
 	void generate_buffer();
 	void write_buffer(const void* data, size_t size);

--- a/duel.h
+++ b/duel.h
@@ -98,7 +98,7 @@ public:
 		if(groups.size() > 2000) {
 			lua->collect();
 		}
-		return std::move(pgroup);
+		return pgroup;
 	}
 	effect* new_effect();
 	void delete_card(card* pcard);

--- a/duel.h
+++ b/duel.h
@@ -102,7 +102,6 @@ public:
 	}
 	effect* new_effect();
 	void delete_card(card* pcard);
-	void delete_group(group* pgroup);
 	void delete_group_no_unref(group* pgroup);
 	void delete_effect(effect* peffect);
 	void release_script_group();

--- a/field.cpp
+++ b/field.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 #include <algorithm> //std::sort, std::swap, std::find, std::find_if, std::min, std::none_of
+#include <tuple> //std::tie
 #include <utility> //std::move
 #include <vector>
 #include "card.h"
@@ -53,15 +54,12 @@ void chain::set_triggering_state(card* pcard) {
 	pcard->get_set_card(setcode);
 }
 bool tevent::operator< (const tevent& rhs) const {
-	return trigger_card < rhs.trigger_card ||
-		event_cards < rhs.event_cards ||
-		reason_effect < rhs.reason_effect ||
-		event_code < rhs.event_code ||
-		event_value < rhs.event_value ||
-		reason < rhs.reason ||
-		event_player < rhs.event_player ||
-		reason_player < rhs.reason_player ||
-		global_id < rhs.global_id;
+	return std::tie(trigger_card, event_cards, reason_effect,
+					event_code, event_value, reason,
+					event_player, reason_player, global_id) <
+		std::tie(rhs.trigger_card, rhs.event_cards, rhs.reason_effect,
+				 rhs.event_code, rhs.event_value, rhs.reason,
+				 rhs.event_player, rhs.reason_player, rhs.global_id);
 }
 field::field(duel* _pduel, const OCG_DuelOptions& options) :pduel(_pduel), player({ {options.team1, options.team2} }) {
 	core.duel_options = options.flags;

--- a/field.cpp
+++ b/field.cpp
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 #include <algorithm> //std::sort, std::swap, std::find, std::find_if, std::min, std::none_of
-#include <cstring> //std::memcmp
 #include <utility> //std::move
 #include <vector>
 #include "card.h"
@@ -53,8 +52,16 @@ void chain::set_triggering_state(card* pcard) {
 	setcode.clear();
 	pcard->get_set_card(setcode);
 }
-bool tevent::operator< (const tevent& v) const {
-	return std::memcmp(this, &v, sizeof(tevent)) < 0;
+bool tevent::operator< (const tevent& rhs) const {
+	return trigger_card < rhs.trigger_card ||
+		event_cards < rhs.event_cards ||
+		reason_effect < rhs.reason_effect ||
+		event_code < rhs.event_code ||
+		event_value < rhs.event_value ||
+		reason < rhs.reason ||
+		event_player < rhs.event_player ||
+		reason_player < rhs.reason_player ||
+		global_id < rhs.global_id;
 }
 field::field(duel* _pduel, const OCG_DuelOptions& options) :pduel(_pduel), player({ {options.team1, options.team2} }) {
 	core.duel_options = options.flags;

--- a/field.h
+++ b/field.h
@@ -20,6 +20,7 @@
 #include "card.h"
 #include "common.h"
 #include "containers_fwd.h"
+#include "lua_obj.h"
 #include "processor_unit.h"
 #include "progressivebuffer.h"
 
@@ -29,7 +30,7 @@ class effect;
 
 struct tevent {
 	card* trigger_card;
-	group* event_cards;
+	owned_lua<group> event_cards;
 	effect* reason_effect;
 	uint32_t event_code;
 	uint32_t event_value;
@@ -40,7 +41,7 @@ struct tevent {
 	bool operator< (const tevent& v) const;
 };
 struct optarget {
-	group* op_cards;
+	owned_lua<group> op_cards;
 	uint8_t op_count;
 	uint8_t op_player;
 	int32_t op_param;
@@ -69,7 +70,7 @@ struct chain {
 	uint32_t flag;
 	uint32_t event_id;
 	effect* triggering_effect;
-	group* target_cards;
+	owned_lua<group> target_cards;
 	effect* disable_reason;
 	applied_chain_counter_t* applied_chain_counters;
 	opmap opinfos;
@@ -311,8 +312,8 @@ struct processor {
 	bool set_forced_attack;
 	card* forced_attacker;
 	card* forced_attack_target;
-	group* must_use_mats;
-	group* only_use_mats;
+	owned_lua<group> must_use_mats;
+	owned_lua<group> only_use_mats;
 	int32_t forced_summon_minc;
 	int32_t forced_summon_maxc;
 	bool attack_cancelable;

--- a/group.h
+++ b/group.h
@@ -20,7 +20,7 @@ class group : public lua_obj_helper<LuaParam::GROUP> {
 public:
 	card_set container;
 	card_set::iterator it;
-	uint8_t is_readonly{ 0 };
+	bool is_readonly{ false };
 	bool is_iterator_dirty{ true };
 	
 	bool has_card(card* c) const {

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -59,6 +59,11 @@ interpreter::interpreter(duel* pd, const OCG_DuelOptions& options): coroutines(2
 		nil_out("loadfile");
 	}
 	{
+		/*
+			Creates a table and sets a metatable to it making a table with weak keys, which
+			will then be used in place of the LUA_REGISTRYINDEX table to keep track of groups
+			when they are not owned by the core
+		*/
 		luaL_checkstack(lua_state, 4, nullptr);
 		lua_newtable(lua_state);
 		lua_newtable(lua_state);

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -176,14 +176,20 @@ void interpreter::register_obj(lua_obj* obj, const char* tablename, bool weak) {
 		obj->ref_handle = ensure_luaL_stack(luaL_ref, lua_state, LUA_REGISTRYINDEX);
 	}
 }
-void interpreter::collect() {
+void interpreter::collect(bool full) {
 	if(!lua_checkstack(current_state, 1)) {
 		return;
 	}
-	lua_pushcfunction(current_state, [](lua_State* L) -> int32_t {
+	// faster and cleaner to just have 2 separate functions than to pass upvalues
+	auto* gcfull = +[](lua_State* L) -> int32_t {
 		lua_gc(L, LUA_GCCOLLECT, 0);
 		return 0;
-	});
+	};
+	auto* gcstep = +[](lua_State* L) -> int32_t {
+		lua_gc(L, LUA_GCSTEP, 0);
+		return 0;
+	};
+	lua_pushcfunction(current_state, (full ? gcfull : gcstep));
 	if(lua_pcall(current_state, 0, 0, 0) != LUA_OK) {
 		lua_pop(current_state, 1);
 	}

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -59,6 +59,7 @@ interpreter::interpreter(duel* pd, const OCG_DuelOptions& options): coroutines(2
 		nil_out("loadfile");
 	}
 	{
+		luaL_checkstack(lua_state, 4, nullptr);
 		lua_newtable(lua_state);
 		lua_newtable(lua_state);
 		lua_pushliteral(lua_state, "__mode");
@@ -156,6 +157,7 @@ void interpreter::register_obj(lua_obj* obj, const char* tablename, bool weak) {
 	if(!obj)
 		return;
 	if(weak) {
+		luaL_checkstack(lua_state, 1, nullptr);
 		lua_rawgeti(lua_state, LUA_REGISTRYINDEX, weak_lua_references);
 	}
 	luaL_checkstack(lua_state, 3, nullptr);
@@ -173,7 +175,16 @@ void interpreter::register_obj(lua_obj* obj, const char* tablename, bool weak) {
 	}
 }
 void interpreter::collect() {
-	lua_gc(lua_state, LUA_GCCOLLECT, 0);
+	if(!lua_checkstack(current_state, 1)) {
+		return;
+	}
+	lua_pushcfunction(current_state, [](lua_State* L) -> int32_t {
+		lua_gc(L, LUA_GCCOLLECT, 0);
+		return 0;
+	});
+	if(lua_pcall(current_state, 0, 0, 0) != LUA_OK) {
+		lua_pop(current_state, 1);
+	}
 }
 bool interpreter::load_script(const char* buffer, int len, const char* script_name) {
 	if(!buffer)
@@ -669,7 +680,17 @@ void lua_obj::incr_ref() {
 void lua_obj::decr_ref() {
 	--num_ref;
 	if(num_ref == 0) {
-		luaL_unref(pduel->lua->current_state, LUA_REGISTRYINDEX, ref_handle);
+		auto* L = pduel->lua->current_state;
+		// TODO: what to do here? assert if this fails?
+		lua_checkstack(L, 2);
+		lua_pushcfunction(L, [](lua_State* L) -> int32_t {
+			ensure_luaL_stack(luaL_unref, L, LUA_REGISTRYINDEX, lua_tointeger(L, 1));
+			return 0;
+		});
+		lua_pushinteger(L, ref_handle);
+		if(lua_pcall(L, 1, 0, 0) != LUA_OK) {
+			lua_pop(L, 1);
+		}
 		ref_handle = 0;
 	}
 }

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -345,7 +345,6 @@ inline int interpreter::call_lua(lua_State* L, int nargs, int nresults) {
 	--no_action;
 	--call_depth;
 	if(call_depth == 0) {
-		pduel->release_script_group();
 		pduel->restore_assumes();
 	}
 	return ret;
@@ -579,7 +578,6 @@ int32_t interpreter::call_coroutine(int32_t function, uint32_t param_count, lua_
 			ensure_luaL_stack(luaL_unref, lua_state, LUA_REGISTRYINDEX, ref);
 			--call_depth;
 			if(call_depth == 0) {
-				pduel->release_script_group();
 				pduel->restore_assumes();
 			}
 			return ret_error("recursive event trigger detected.");
@@ -608,7 +606,6 @@ int32_t interpreter::call_coroutine(int32_t function, uint32_t param_count, lua_
 	ensure_luaL_stack(luaL_unref, lua_state, LUA_REGISTRYINDEX, ref);
 	--call_depth;
 	if(call_depth == 0) {
-		pduel->release_script_group();
 		pduel->restore_assumes();
 	}
 	return (result == LUA_OK) ? COROUTINE_FINISH : COROUTINE_ERROR;

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -150,9 +150,6 @@ void interpreter::unregister_effect(effect* peffect) {
 void interpreter::register_group(group* pgroup) {
 	register_obj(pgroup, "Group", true);
 }
-void interpreter::unregister_group(group* pgroup) {
-	remove_object(lua_state, pgroup, pgroup);
-}
 void interpreter::register_obj(lua_obj* obj, const char* tablename, bool weak) {
 	if(!obj)
 		return;

--- a/interpreter.cpp
+++ b/interpreter.cpp
@@ -58,6 +58,15 @@ interpreter::interpreter(duel* pd, const OCG_DuelOptions& options): coroutines(2
 		nil_out("dofile");
 		nil_out("loadfile");
 	}
+	{
+		lua_newtable(lua_state);
+		lua_newtable(lua_state);
+		lua_pushliteral(lua_state, "__mode");
+		lua_pushliteral(lua_state, "v");
+		lua_rawset(lua_state, -3); // metatable._mode='v'
+		lua_setmetatable(lua_state, -2);
+		weak_lua_references = ensure_luaL_stack(luaL_ref, lua_state, LUA_REGISTRYINDEX);
+	}
 	// Open all card scripting libs
 	scriptlib::push_card_lib(lua_state);
 	scriptlib::push_effect_lib(lua_state);
@@ -118,7 +127,7 @@ static inline void remove_object(lua_State* L, lua_obj* obj, lua_obj* replacemen
 	obj->ref_handle = 0;
 }
 void interpreter::register_effect(effect* peffect) {
-	register_obj(peffect, "Effect");
+	register_obj(peffect, "Effect", false);
 }
 void interpreter::unregister_effect(effect* peffect) {
 	if (!peffect)
@@ -138,14 +147,17 @@ void interpreter::unregister_effect(effect* peffect) {
 	remove_object(lua_state, peffect, &deleted);
 }
 void interpreter::register_group(group* pgroup) {
-	register_obj(pgroup, "Group");
+	register_obj(pgroup, "Group", true);
 }
 void interpreter::unregister_group(group* pgroup) {
-	remove_object(lua_state, pgroup, &deleted);
+	remove_object(lua_state, pgroup, pgroup);
 }
-void interpreter::register_obj(lua_obj* obj, const char* tablename) {
+void interpreter::register_obj(lua_obj* obj, const char* tablename, bool weak) {
 	if(!obj)
 		return;
+	if(weak) {
+		lua_rawgeti(lua_state, LUA_REGISTRYINDEX, weak_lua_references);
+	}
 	luaL_checkstack(lua_state, 3, nullptr);
 	lua_obj** pobj = create_object(lua_state);
 	*pobj = obj;
@@ -153,7 +165,15 @@ void interpreter::register_obj(lua_obj* obj, const char* tablename) {
 	lua_getglobal(lua_state, tablename);
 	lua_setmetatable(lua_state, -2);
 	//pops the lua object from the stack and takes a reference of it
-	obj->ref_handle = ensure_luaL_stack(luaL_ref, lua_state, LUA_REGISTRYINDEX);
+	if(weak) {
+		obj->weak_ref_handle = ensure_luaL_stack(luaL_ref, lua_state, -2);
+		lua_pop(lua_state, 1);
+	} else {
+		obj->ref_handle = ensure_luaL_stack(luaL_ref, lua_state, LUA_REGISTRYINDEX);
+	}
+}
+void interpreter::collect() {
+	lua_gc(lua_state, LUA_GCCOLLECT, 0);
 }
 bool interpreter::load_script(const char* buffer, int len, const char* script_name) {
 	if(!buffer)
@@ -578,6 +598,16 @@ int32_t interpreter::clone_lua_ref(int32_t lua_ref) {
 	lua_rawgeti(current_state, LUA_REGISTRYINDEX, lua_ref);
 	return ensure_luaL_stack(luaL_ref, current_state, LUA_REGISTRYINDEX);
 }
+int32_t interpreter::strong_from_weak_ref(int32_t weak_lua_ref) {
+	push_weak_ref(current_state, weak_lua_ref);
+	return ensure_luaL_stack(luaL_ref, current_state, LUA_REGISTRYINDEX);
+}
+void interpreter::push_weak_ref(lua_State* L, int32_t weak_lua_ref) {
+	luaL_checkstack(L, 2, nullptr);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, weak_lua_references);
+	lua_rawgeti(L, -1, weak_lua_ref);
+	lua_remove(L, -2);
+}
 void* interpreter::get_ref_object(int32_t ref_handler) {
 	if(ref_handler == 0)
 		return nullptr;
@@ -589,8 +619,10 @@ void* interpreter::get_ref_object(int32_t ref_handler) {
 }
 //Convert a pointer to a lua value, +1 -0
 void interpreter::pushobject(lua_State* L, lua_obj* obj) {
-	if(!obj || obj->ref_handle == 0)
+	if(!obj || (obj->ref_handle == 0 && obj->weak_ref_handle == 0))
 		lua_pushnil(L);
+	else if(obj->ref_handle == 0)
+		obj->pduel->lua->push_weak_ref(L, obj->weak_ref_handle);
 	else
 		lua_rawgeti(L, LUA_REGISTRYINDEX, obj->ref_handle);
 }
@@ -625,4 +657,19 @@ void interpreter::print_stacktrace(lua_State* L) {
 	if(len > sizeof("stack traceback:"))
 		pduel->handle_message(lua_get_string_or_empty(L, -1), OCG_LOG_TYPE_FOR_DEBUG);
 	lua_pop(L, 1);
+}
+
+void lua_obj::incr_ref() {
+	if(ref_handle == 0) {
+		ref_handle = pduel->lua->strong_from_weak_ref(weak_ref_handle);
+	}
+	++num_ref;
+}
+
+void lua_obj::decr_ref() {
+	--num_ref;
+	if(num_ref == 0) {
+		luaL_unref(pduel->lua->current_state, LUA_REGISTRYINDEX, ref_handle);
+		ref_handle = 0;
+	}
 }

--- a/interpreter.h
+++ b/interpreter.h
@@ -65,7 +65,7 @@ public:
 	void register_group(group* pgroup);
 	void register_obj(lua_obj* obj, const char* tablename, bool weak);
 
-	void collect();
+	void collect(bool full = false);
 
 	bool load_script(const char* buffer, int len = 0, const char* script_name = nullptr);
 	bool load_card_script(uint32_t code);

--- a/interpreter.h
+++ b/interpreter.h
@@ -63,7 +63,6 @@ public:
 	void register_effect(effect* peffect);
 	void unregister_effect(effect* peffect);
 	void register_group(group* pgroup);
-	void unregister_group(group* pgroup);
 	void register_obj(lua_obj* obj, const char* tablename, bool weak);
 
 	void collect();

--- a/interpreter.h
+++ b/interpreter.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010-2015, Argon Sun (Fluorohydride)
- * Copyright (c) 2017-2024, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
+ * Copyright (c) 2017-2025, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -54,6 +54,7 @@ public:
 	int32_t no_action;
 	int32_t call_depth;
 	lua_invalid deleted;
+	int weak_lua_references;
 
 	interpreter(duel* pd, const OCG_DuelOptions& options);
 	~interpreter();
@@ -63,7 +64,9 @@ public:
 	void unregister_effect(effect* peffect);
 	void register_group(group* pgroup);
 	void unregister_group(group* pgroup);
-	void register_obj(lua_obj* obj, const char* tablename);
+	void register_obj(lua_obj* obj, const char* tablename, bool weak);
+
+	void collect();
 
 	bool load_script(const char* buffer, int len = 0, const char* script_name = nullptr);
 	bool load_card_script(uint32_t code);
@@ -93,6 +96,8 @@ public:
 	bool get_function_value(int32_t f, uint32_t param_count, std::vector<lua_Integer>& result);
 	int32_t call_coroutine(int32_t f, uint32_t param_count, lua_Integer* yield_value, uint16_t step);
 	int32_t clone_lua_ref(int32_t lua_ref);
+	int32_t strong_from_weak_ref(int32_t weak_lua_ref);
+	void push_weak_ref(lua_State* L, int32_t weak_lua_ref);
 	void* get_ref_object(int32_t ref_handler);
 	bool call_function(int param_count, int ret_count);
 	inline bool ret_fail(const char* message);

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010-2015, Argon Sun (Fluorohydride)
- * Copyright (c) 2017-2024, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
+ * Copyright (c) 2017-2025, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */

--- a/libcard.cpp
+++ b/libcard.cpp
@@ -217,7 +217,7 @@ LUA_FUNCTION(IsLinkMarker) {
 LUA_FUNCTION(GetLinkedGroup) {
 	card_set cset;
 	self->get_linked_cards(&cset);
-	group* pgroup = pduel->new_group(cset);
+	auto pgroup = pduel->new_group(cset);
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -248,7 +248,7 @@ LUA_FUNCTION(GetFreeLinkedZone) {
 LUA_FUNCTION(GetMutualLinkedGroup) {
 	card_set cset;
 	self->get_mutual_linked_cards(&cset);
-	group* pgroup = pduel->new_group(cset);
+	auto pgroup = pduel->new_group(cset);
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -280,7 +280,7 @@ LUA_FUNCTION(GetColumnGroup) {
 	auto right = lua_get<uint8_t, 0>(L, 3);
 	card_set cset;
 	self->get_column_cards(&cset, left, right);
-	group* pgroup = pduel->new_group(cset);
+	auto pgroup = pduel->new_group(cset);
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -888,7 +888,7 @@ LUA_FUNCTION(SetMaterial) {
 	return 0;
 }
 LUA_FUNCTION(GetMaterial) {
-	group* pgroup = pduel->new_group(self->material_cards);
+	auto pgroup = pduel->new_group(self->material_cards);
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -897,7 +897,7 @@ LUA_FUNCTION(GetMaterialCount) {
 	return 1;
 }
 LUA_FUNCTION(GetEquipGroup) {
-	group* pgroup = pduel->new_group(self->equiping_cards);
+	auto pgroup = pduel->new_group(self->equiping_cards);
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -939,7 +939,7 @@ LUA_FUNCTION(GetUnionCount) {
 	return 2;
 }
 LUA_FUNCTION(GetOverlayGroup) {
-	group* pgroup = pduel->new_group(self->xyz_materials);
+	auto pgroup = pduel->new_group(self->xyz_materials);
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -958,7 +958,7 @@ LUA_FUNCTION(CheckRemoveOverlayCard) {
 		return 0;
 	auto count = lua_get<uint16_t>(L, 3);
 	auto reason = lua_get<uint32_t>(L, 4);
-	group* pgroup = pduel->new_group(self);
+	auto pgroup = pduel->new_group(self);
 	lua_pushboolean(L, pduel->game_field->is_player_can_remove_overlay_card(playerid, pgroup, 0, 0, count, reason));
 	return 1;
 }
@@ -971,7 +971,7 @@ LUA_FUNCTION(RemoveOverlayCard) {
 	auto min = lua_get<uint16_t>(L, 3);
 	auto max = lua_get<uint16_t>(L, 4);
 	auto reason = lua_get<uint32_t>(L, 5);
-	group* pgroup = pduel->new_group(self);
+	auto pgroup = pduel->new_group(self);
 	pduel->game_field->remove_overlay_card(reason, pgroup, playerid, 0, 0, min, max);
 	return yieldk({
 		lua_pushinteger(L, pduel->game_field->returns.at<int32_t>(0));
@@ -979,7 +979,7 @@ LUA_FUNCTION(RemoveOverlayCard) {
 	});
 }
 LUA_FUNCTION(GetAttackedGroup) {
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	for(auto& cit : self->attacked_cards) {
 		if(cit.second.first)
 			pgroup->container.insert(cit.second.first);
@@ -996,7 +996,7 @@ LUA_FUNCTION(GetAttackedCount) {
 	return 1;
 }
 LUA_FUNCTION(GetBattledGroup) {
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	for(auto& cit : self->battled_cards) {
 		if(cit.second.first)
 			pgroup->container.insert(cit.second.first);
@@ -1023,7 +1023,7 @@ LUA_FUNCTION(SetCardTarget) {
 	return 0;
 }
 LUA_FUNCTION(GetCardTarget) {
-	group* pgroup = pduel->new_group(self->effect_target_cards);
+	auto pgroup = pduel->new_group(self->effect_target_cards);
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -1050,7 +1050,7 @@ LUA_FUNCTION(CancelCardTarget) {
 	return 0;
 }
 LUA_FUNCTION(GetOwnerTarget) {
-	group* pgroup = pduel->new_group(self->effect_target_owner);
+	auto pgroup = pduel->new_group(self->effect_target_owner);
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -1383,8 +1383,8 @@ inline int32_t spsummonable_rule(lua_State* L, uint32_t cardtype, uint32_t sumty
 	auto pcard = lua_get<card*, true>(L, 1);
 	if(!(pcard->data.type & cardtype))
 		return 0;
-	group* must = nullptr;
-	group* materials = nullptr;
+	owned_lua<group> must = nullptr;
+	owned_lua<group> materials = nullptr;
 	if(auto [pcard_, pgroup_] = lua_get_card_or_group<true>(L, 2 + offset); pcard_)
 		must = pduel->new_group(pcard_);
 	else if(pgroup_)
@@ -1921,10 +1921,10 @@ LUA_FUNCTION(IsCanBeMaterial) {
 	return 1;
 }
 LUA_FUNCTION(CheckFusionMaterial) {
-	group* pgroup = nullptr;
+	owned_lua<group> pgroup = nullptr;
 	if(lua_gettop(L) > 1 && !lua_isnoneornil(L, 2))
 		pgroup = lua_get<group*, true>(L, 2);
-	group* cg = nullptr;
+	owned_lua<group> cg = nullptr;
 	if(auto _pcard = lua_get<card*>(L, 3))
 		cg = pduel->new_group(_pcard);
 	else
@@ -2045,7 +2045,7 @@ LUA_FUNCTION(GetAttackableTarget) {
 	card_vector targets;
 	bool chain_attack = pduel->game_field->core.chain_attacker_id == self->fieldid;
 	pduel->game_field->get_attack_target(self, &targets, chain_attack);
-	group* newgroup = pduel->new_group(targets);
+	auto newgroup = pduel->new_group(targets);
 	interpreter::pushobject(L, newgroup);
 	lua_pushboolean(L, self->direct_attackable);
 	return 2;

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -277,18 +277,18 @@ inline int32_t spsummon_rule(lua_State* L, uint32_t summon_type, uint32_t offset
 	owned_lua<group> must = nullptr;
 	if(auto _pcard = lua_get<card*>(L, 3 + offset)) {
 		must = pduel->new_group(_pcard);
-		must->is_readonly = TRUE;
+		must->is_readonly = true;
 	} else if(auto pgroup = lua_get<group*>(L, 3 + offset)) {
 		must = pduel->new_group(pgroup);
-		must->is_readonly = TRUE;
+		must->is_readonly = true;
 	}
 	owned_lua<group> materials = nullptr;
 	if(auto _pcard = lua_get<card*>(L, 4 + offset)) {
 		materials = pduel->new_group(_pcard);
-		materials->is_readonly = TRUE;
+		materials->is_readonly = true;
 	} else if(auto pgroup = lua_get<group*>(L, 4 + offset)) {
 		materials = pduel->new_group(pgroup);
-		materials->is_readonly = TRUE;
+		materials->is_readonly = true;
 	}
 	auto minc = lua_get<uint16_t, 0>(L, 5 + offset);
 	auto maxc = lua_get<uint16_t, 0>(L, 6 + offset);
@@ -2668,7 +2668,7 @@ LUA_STATIC_FUNCTION(SelectTarget) {
 		if(ch) {
 			if(!ch->target_cards) {
 				ch->target_cards = pduel->new_group();
-				ch->target_cards->is_readonly = TRUE;
+				ch->target_cards->is_readonly = true;
 			}
 			ch->target_cards->container.insert(pduel->game_field->return_cards.list.begin(), pduel->game_field->return_cards.list.end());
 			effect* peffect = ch->triggering_effect;
@@ -2772,7 +2772,7 @@ LUA_STATIC_FUNCTION(SetTargetCard) {
 		return 0;
 	if(!ch->target_cards) {
 		ch->target_cards = pduel->new_group();
-		ch->target_cards->is_readonly = TRUE;
+		ch->target_cards->is_readonly = true;
 	}
 	auto targets = ch->target_cards;
 	effect* peffect = ch->triggering_effect;
@@ -2852,7 +2852,7 @@ LUA_STATIC_FUNCTION(SetOperationInfo) {
 		// and the core always assume the group is exactly 2 cards
 		if(cate == 0x200 && playerid == PLAYER_ALL && opt.op_cards->container.size() != 2)
 			lua_error(L, "Called Duel.SetOperationInfo with CATEGORY_SPECIAL_SUMMON and PLAYER_ALL but the group size wasn't exactly 2.");
-		opt.op_cards->is_readonly = TRUE;
+		opt.op_cards->is_readonly = true;
 	}
 	auto omit = ch->opinfos.find(cate);
 	if(omit != ch->opinfos.end() && omit->second.op_cards)
@@ -2899,7 +2899,7 @@ LUA_STATIC_FUNCTION(SetPossibleOperationInfo) {
 	optarget opt{ nullptr, count, playerid, param };
 	if(pobj && (pobj->lua_type == LuaParam::CARD || pobj->lua_type == LuaParam::GROUP)) {
 		opt.op_cards = pduel->new_group(pobj);
-		opt.op_cards->is_readonly = TRUE;
+		opt.op_cards->is_readonly = true;
 	}
 	auto omit = ch->possibleopinfos.find(cate);
 	if(omit != ch->possibleopinfos.end() && omit->second.op_cards)

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -2854,9 +2854,6 @@ LUA_STATIC_FUNCTION(SetOperationInfo) {
 			lua_error(L, "Called Duel.SetOperationInfo with CATEGORY_SPECIAL_SUMMON and PLAYER_ALL but the group size wasn't exactly 2.");
 		opt.op_cards->is_readonly = true;
 	}
-	auto omit = ch->opinfos.find(cate);
-	if(omit != ch->opinfos.end() && omit->second.op_cards)
-		pduel->delete_group(omit->second.op_cards);
 	ch->opinfos[cate] = std::move(opt);
 	return 0;
 }
@@ -2901,9 +2898,6 @@ LUA_STATIC_FUNCTION(SetPossibleOperationInfo) {
 		opt.op_cards = pduel->new_group(pobj);
 		opt.op_cards->is_readonly = true;
 	}
-	auto omit = ch->possibleopinfos.find(cate);
-	if(omit != ch->possibleopinfos.end() && omit->second.op_cards)
-		pduel->delete_group(omit->second.op_cards);
 	ch->possibleopinfos[cate] = std::move(opt);
 	return 0;
 }
@@ -2947,15 +2941,7 @@ LUA_STATIC_FUNCTION(ClearOperationInfo) {
 	chain* ch = pduel->game_field->get_chain(ct);
 	if(!ch)
 		return 0;
-	for(auto& oit : ch->opinfos) {
-		if(oit.second.op_cards)
-			pduel->delete_group(oit.second.op_cards);
-	}
 	ch->opinfos.clear();
-	for(auto& oit : ch->possibleopinfos) {
-		if(oit.second.op_cards)
-			pduel->delete_group(oit.second.op_cards);
-	}
 	ch->possibleopinfos.clear();
 	return 0;
 }

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -274,7 +274,7 @@ inline int32_t spsummon_rule(lua_State* L, uint32_t summon_type, uint32_t offset
 	if(playerid != 0 && playerid != 1)
 		return 0;
 	auto pcard = lua_get<card*, true>(L, 2);
-	group* must = nullptr;
+	owned_lua<group> must = nullptr;
 	if(auto _pcard = lua_get<card*>(L, 3 + offset)) {
 		must = pduel->new_group(_pcard);
 		must->is_readonly = TRUE;
@@ -282,7 +282,7 @@ inline int32_t spsummon_rule(lua_State* L, uint32_t summon_type, uint32_t offset
 		must = pduel->new_group(pgroup);
 		must->is_readonly = TRUE;
 	}
-	group* materials = nullptr;
+	owned_lua<group> materials = nullptr;
 	if(auto _pcard = lua_get<card*>(L, 4 + offset)) {
 		materials = pduel->new_group(_pcard);
 		materials->is_readonly = TRUE;
@@ -561,7 +561,7 @@ LUA_STATIC_FUNCTION(RemoveCards) {
 	return 0;
 }
 LUA_STATIC_FUNCTION(GetOperatedGroup) {
-	group* pgroup = pduel->new_group(pduel->game_field->core.operated_set);
+	auto pgroup = pduel->new_group(pduel->game_field->core.operated_set);
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -1310,7 +1310,7 @@ LUA_STATIC_FUNCTION(DiscardHand) {
 	auto min = lua_get<uint16_t>(L, 3);
 	auto max = lua_get<uint16_t>(L, 4);
 	auto reason = lua_get<uint32_t>(L, 5);
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	pduel->game_field->filter_matching_card(findex, playerid, LOCATION_HAND, 0, pgroup, pexception, pexgroup, extraargs);
 	pduel->game_field->core.select_cards.assign(pgroup->container.begin(), pgroup->container.end());
 	if(pduel->game_field->core.select_cards.size() == 0) {
@@ -1804,7 +1804,7 @@ LUA_STATIC_FUNCTION(GetLinkedGroup) {
 		location2 = LOCATION_MZONE;
 	card_set cset;
 	pduel->game_field->get_linked_cards(rplayer, location1, location2, &cset);
-	group* pgroup = pduel->new_group(std::move(cset));
+	auto pgroup = pduel->new_group(std::move(cset));
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -2163,7 +2163,7 @@ LUA_STATIC_FUNCTION(GetFieldGroup) {
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto location1 = lua_get<uint16_t>(L, 2);
 	auto location2 = lua_get<uint16_t>(L, 3);
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	pduel->game_field->filter_field_card(playerid, location1, location2, pgroup);
 	interpreter::pushobject(L, pgroup);
 	return 1;
@@ -2193,7 +2193,7 @@ LUA_STATIC_FUNCTION(GetDecktopGroup) {
 	auto& main = pduel->game_field->player[playerid].list_main;
 	const auto count = std::min<size_t>(lua_get<uint32_t>(L, 2), main.size());
 	const auto offset = main.size() - count;
-	group* pgroup = pduel->new_group(main.begin() + offset, main.end());
+	auto pgroup = pduel->new_group(main.begin() + offset, main.end());
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -2202,7 +2202,7 @@ LUA_STATIC_FUNCTION(GetDeckbottomGroup) {
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto& main = pduel->game_field->player[playerid].list_main;
 	const auto count = std::min<size_t>(lua_get<uint32_t>(L, 2), main.size());
-	group* pgroup = pduel->new_group(main.begin(), main.begin() + count);
+	auto pgroup = pduel->new_group(main.begin(), main.begin() + count);
 	interpreter::pushobject(L, pgroup);
 	return 1;
 }
@@ -2215,7 +2215,7 @@ LUA_STATIC_FUNCTION(GetExtraTopGroup) {
 	check_param_count(L, 2);
 	auto playerid = lua_get<uint8_t>(L, 1);
 	auto count = lua_get<uint32_t>(L, 2);
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	auto cit = pduel->game_field->player[playerid].list_extra.rbegin() + pduel->game_field->player[playerid].extra_p_count;
 	for(uint32_t i = 0; i < count && cit != pduel->game_field->player[playerid].list_extra.rend(); ++i, ++cit)
 		pgroup->container.insert(*cit);
@@ -2238,7 +2238,7 @@ LUA_STATIC_FUNCTION(GetMatchingGroup) {
 	auto self = lua_get<uint8_t>(L, 2);
 	auto location1 = lua_get<uint16_t>(L, 3);
 	auto location2 = lua_get<uint16_t>(L, 4);
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	pduel->game_field->filter_matching_card(findex, self, location1, location2, pgroup, pexception, pexgroup, extraargs);
 	interpreter::pushobject(L, pgroup);
 	return 1;
@@ -2259,7 +2259,7 @@ LUA_STATIC_FUNCTION(GetMatchingGroupCount) {
 	auto self = lua_get<uint8_t>(L, 2);
 	auto location1 = lua_get<uint16_t>(L, 3);
 	auto location2 = lua_get<uint16_t>(L, 4);
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	pduel->game_field->filter_matching_card(findex, self, location1, location2, pgroup, pexception, pexgroup, extraargs);
 	lua_pushinteger(L, pgroup->container.size());
 	return 1;
@@ -2336,7 +2336,7 @@ LUA_STATIC_FUNCTION(SelectMatchingCard) {
 	auto location2 = lua_get<uint16_t>(L, 5);
 	auto min = lua_get<uint16_t>(L, 6);
 	auto max = lua_get<uint16_t>(L, 7);
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	pduel->game_field->filter_matching_card(findex, self, location1, location2, pgroup, pexception, pexgroup, extraargs);
 	pduel->game_field->core.select_cards.assign(pgroup->container.begin(), pgroup->container.end());
 	pduel->game_field->emplace_process<Processors::SelectCard>(playerid, cancelable, min, max);
@@ -2395,7 +2395,7 @@ LUA_STATIC_FUNCTION(GetReleaseGroup) {
 	bool hand = lua_get<bool, false>(L, 2);
 	bool oppo = lua_get<bool, false>(L, 3);
 	const auto reason = lua_get<uint32_t, REASON_COST>(L, 4);
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	pduel->game_field->get_release_list(playerid, &pgroup->container, &pgroup->container, &pgroup->container, hand, 0, 0, nullptr, nullptr, oppo, reason);
 	interpreter::pushobject(L, pgroup);
 	return 1;
@@ -2523,7 +2523,7 @@ LUA_STATIC_FUNCTION(SelectReleaseGroupEx) {
 LUA_STATIC_FUNCTION(GetTributeGroup) {
 	check_param_count(L, 1);
 	auto target = lua_get<card*, true>(L, 1);
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	pduel->game_field->get_summon_release_list(target, &(pgroup->container), &(pgroup->container), &(pgroup->container));
 	interpreter::pushobject(L, pgroup);
 	return 1;
@@ -2599,7 +2599,7 @@ LUA_STATIC_FUNCTION(GetTargetCount) {
 	auto self = lua_get<uint8_t>(L, 2);
 	auto location1 = lua_get<uint16_t>(L, 3);
 	auto location2 = lua_get<uint16_t>(L, 4);
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	pduel->game_field->filter_matching_card(findex, self, location1, location2, pgroup, pexception, pexgroup, extraargs, nullptr, 0, true);
 	lua_pushinteger(L, pgroup->container.size());
 	return 1;
@@ -2655,7 +2655,7 @@ LUA_STATIC_FUNCTION(SelectTarget) {
 	auto max = lua_get<uint16_t>(L, 7);
 	if(pduel->game_field->core.current_chain.size() == 0)
 		return 0;
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	pduel->game_field->filter_matching_card(findex, self, location1, location2, pgroup, pexception, pexgroup, extraargs, nullptr, 0, true);
 	pduel->game_field->core.select_cards.assign(pgroup->container.begin(), pgroup->container.end());
 	pduel->game_field->emplace_process<Processors::SelectCard>(playerid, cancelable, min, max);
@@ -2675,7 +2675,7 @@ LUA_STATIC_FUNCTION(SelectTarget) {
 			if(peffect->type & EFFECT_TYPE_CONTINUOUS) {
 				interpreter::pushobject(L, ch->target_cards);
 			} else {
-				group* pret = pduel->new_group(pduel->game_field->return_cards.list);
+				auto pret = pduel->new_group(pduel->game_field->return_cards.list);
 				for(auto& pcard : pret->container) {
 					pcard->create_relation(*ch);
 					if(peffect->is_flag(EFFECT_FLAG_CARD_TARGET)) {
@@ -2698,7 +2698,7 @@ LUA_STATIC_FUNCTION(SelectFusionMaterial) {
 		return 0;
 	auto pcard = lua_get<card*, true>(L, 2);
 	auto pgroup = lua_get<group*, true>(L, 3);
-	group* forced_materials = nullptr;
+	owned_lua<group> forced_materials = nullptr;
 	if(auto pcard_ = lua_get<card*>(L, 4))
 		forced_materials = pduel->new_group(pcard_);
 	else
@@ -2706,7 +2706,7 @@ LUA_STATIC_FUNCTION(SelectFusionMaterial) {
 	auto chkf = lua_get<uint32_t, PLAYER_NONE>(L, 5);
 	pduel->game_field->emplace_process<Processors::SelectFusion>(playerid, pgroup, chkf, forced_materials, pcard);
 	return yieldk({
-		group* pgroup = pduel->new_group(pduel->game_field->core.fusion_materials);
+		auto pgroup = pduel->new_group(pduel->game_field->core.fusion_materials);
 		interpreter::pushobject(L, pgroup);
 		return 1;
 	});
@@ -2723,7 +2723,7 @@ LUA_STATIC_FUNCTION(GetRitualMaterial) {
 	if(playerid != 0 && playerid != 1)
 		return 0;
 	bool check_level = lua_get<bool, true>(L, 2);
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	pduel->game_field->get_ritual_material(playerid, pduel->game_field->core.reason_effect, &pgroup->container, check_level);
 	interpreter::pushobject(L, pgroup);
 	return 1;
@@ -2740,7 +2740,7 @@ LUA_STATIC_FUNCTION(GetFusionMaterial) {
 	auto playerid = lua_get<uint8_t>(L, 1);
 	if(playerid != 0 && playerid != 1)
 		return 0;
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	pduel->game_field->get_fusion_material(playerid, &pgroup->container);
 	interpreter::pushobject(L, pgroup);
 	return 1;
@@ -2758,7 +2758,7 @@ LUA_STATIC_FUNCTION(SetSelectedCard) {
 	return 0;
 }
 LUA_STATIC_FUNCTION(GrabSelectedCard) {
-	group* pgroup = pduel->new_group(pduel->game_field->core.must_select_cards);
+	auto pgroup = pduel->new_group(pduel->game_field->core.must_select_cards);
 	pduel->game_field->core.must_select_cards.clear();
 	interpreter::pushobject(L, pgroup);
 	return 1;
@@ -2774,7 +2774,7 @@ LUA_STATIC_FUNCTION(SetTargetCard) {
 		ch->target_cards = pduel->new_group();
 		ch->target_cards->is_readonly = TRUE;
 	}
-	group* targets = ch->target_cards;
+	auto targets = ch->target_cards;
 	effect* peffect = ch->triggering_effect;
 	if(peffect->type & EFFECT_TYPE_CONTINUOUS) {
 		if(pcard)
@@ -2986,7 +2986,7 @@ LUA_STATIC_FUNCTION(GetOverlayGroup) {
 	auto self = lua_get<uint8_t>(L, 2);
 	auto oppo = lua_get<uint8_t>(L, 3);
 	group* targetsgroup = lua_get<group*>(L, 4);
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	pduel->game_field->get_overlay_group(rplayer, self, oppo, &pgroup->container, targetsgroup);
 	interpreter::pushobject(L, pgroup);
 	return 1;

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -25,7 +25,7 @@ namespace {
 using namespace scriptlib;
 
 void assert_readonly_group(lua_State* L, group* pgroup) {
-	if(pgroup->is_readonly != 1)
+	if(!pgroup->is_readonly)
 		return;
 	lua_error(L, "attempt to modify a read only group");
 }

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -727,7 +727,7 @@ LUA_FUNCTION(__le) {
 	return 1;
 }
 LUA_FUNCTION(__gc) {
-	pduel->delete_group_no_unref(self);
+	pduel->delete_group(self);
 	return 1;
 }
 LUA_FUNCTION(IsContains) {

--- a/libgroup.cpp
+++ b/libgroup.cpp
@@ -31,7 +31,7 @@ void assert_readonly_group(lua_State* L, group* pgroup) {
 }
 
 LUA_STATIC_FUNCTION(CreateGroup) {
-	group* pgroup = pduel->new_group();
+	auto pgroup = pduel->new_group();
 	lua_iterate_table_or_stack(L, 1, lua_gettop(L), [L, &container = pgroup->container] {
 		if(!lua_isnil(L, -1)) {
 			auto pcard = lua_get<card*, true>(L, -1);
@@ -43,22 +43,14 @@ LUA_STATIC_FUNCTION(CreateGroup) {
 }
 LUA_FUNCTION_ALIAS(FromCards);
 LUA_FUNCTION(Clone) {
-	group* newgroup = pduel->new_group(self);
+	auto newgroup = pduel->new_group(self);
 	interpreter::pushobject(L, newgroup);
 	return 1;
 }
 LUA_FUNCTION(DeleteGroup) {
-	if(self->is_readonly != 2)
-		return 0;
-	self->is_readonly = 0;
-	pduel->sgroups.insert(self);
 	return 0;
 }
 LUA_FUNCTION(KeepAlive) {
-	if(self->is_readonly != 1) {
-		self->is_readonly = 2;
-		pduel->sgroups.erase(self);
-	}
 	interpreter::pushobject(L, self);
 	return 1;
 }
@@ -140,7 +132,7 @@ LUA_FUNCTION(Filter) {
 		for(auto& pcard : pexgroup->container)
 			cset.erase(pcard);
 	}
-	group* new_group = pduel->new_group();
+	auto new_group = pduel->new_group();
 	uint32_t extraargs = lua_gettop(L) - 3;
 	for(auto& pcard : cset) {
 		if(pduel->lua->check_matching(pcard, findex, extraargs)) {
@@ -313,7 +305,7 @@ LUA_FUNCTION(RandomSelect) {
 	check_param_count(L, 3);
 	auto playerid = lua_get<uint8_t>(L, 2);
 	size_t count = lua_get<uint32_t>(L, 3);
-	group* newgroup = pduel->new_group();
+	auto newgroup = pduel->new_group();
 	if(count > self->container.size())
 		count = self->container.size();
 	if(count == 0) {
@@ -422,13 +414,13 @@ LUA_FUNCTION(SelectWithSumEqual) {
 	}
 	if(!field::check_with_sum_limit_m(cv, acc, 0, min, max, mcount, nullptr)) {
 		pduel->game_field->core.must_select_cards.clear();
-		group* empty_group = pduel->new_group();
+		auto empty_group = pduel->new_group();
 		interpreter::pushobject(L, empty_group);
 		return 1;
 	}
 	pduel->game_field->emplace_process<Processors::SelectSum>(playerid, acc, min, max);
 	return yieldk({
-		group* pgroup = pduel->new_group(pduel->game_field->return_cards.list);
+		auto pgroup = pduel->new_group(pduel->game_field->return_cards.list);
 		pduel->game_field->core.must_select_cards.clear();
 		interpreter::pushobject(L, pgroup);
 		return 1;
@@ -482,13 +474,13 @@ LUA_FUNCTION(SelectWithSumGreater) {
 	}
 	if(!field::check_with_sum_greater_limit_m(cv, acc, 0, 0xffff, mcount, nullptr)) {
 		pduel->game_field->core.must_select_cards.clear();
-		group* empty_group = pduel->new_group();
+		auto empty_group = pduel->new_group();
 		interpreter::pushobject(L, empty_group);
 		return 1;
 	}
 	pduel->game_field->emplace_process<Processors::SelectSum>(playerid, acc, 0, 0);
 	return yieldk({
-		group* pgroup = pduel->new_group(pduel->game_field->return_cards.list);
+		auto pgroup = pduel->new_group(pduel->game_field->return_cards.list);
 		pduel->game_field->core.must_select_cards.clear();
 		interpreter::pushobject(L, pgroup);
 		return 1;
@@ -499,7 +491,7 @@ LUA_FUNCTION(GetMinGroup) {
 	const auto findex = lua_get<function, true>(L, 2);
 	if(self->container.size() == 0)
 		return 0;
-	group* newgroup = pduel->new_group();
+	auto newgroup = pduel->new_group();
 	int64_t min, op;
 	int32_t extraargs = lua_gettop(L) - 2;
 	auto cit = self->container.begin();
@@ -525,7 +517,7 @@ LUA_FUNCTION(GetMaxGroup) {
 	const auto findex = lua_get<function, true>(L, 2);
 	if(self->container.size() == 0)
 		return 0;
-	group* newgroup = pduel->new_group();
+	auto newgroup = pduel->new_group();
 	int64_t max, op;
 	int32_t extraargs = lua_gettop(L) - 2;
 	auto cit = self->container.begin();
@@ -669,8 +661,9 @@ std::tuple<group*, group*, card*> get_binary_op_group_card_parameters(lua_State*
 }
 LUA_STATIC_FUNCTION(__band) {
 	check_param_count(L, 2);
+	auto [pgroup1, pgroup2, pcard] = get_binary_op_group_card_parameters(L);
 	card_set cset;
-	if(auto [pgroup1, pgroup2, pcard] = get_binary_op_group_card_parameters(L); pcard) {
+	if(pcard) {
 		if(pgroup1->has_card(pcard)) {
 			cset.insert(pcard);
 		}
@@ -684,7 +677,7 @@ LUA_STATIC_FUNCTION(__band) {
 LUA_STATIC_FUNCTION(__add) {
 	check_param_count(L, 2);
 	auto [pgroup1, pgroup2, pcard] = get_binary_op_group_card_parameters(L);
-	group* newgroup = pduel->new_group(pgroup1);
+	auto newgroup = pduel->new_group(pgroup1);
 	if(pcard) {
 		newgroup->container.insert(pcard);
 	} else {
@@ -696,7 +689,7 @@ LUA_STATIC_FUNCTION(__add) {
 LUA_FUNCTION(__sub) {
 	check_param_count(L, 2);
 	auto [pcard, pgroup] = lua_get_card_or_group(L, 2);
-	group* newgroup = pduel->new_group(self);
+	auto newgroup = pduel->new_group(self);
 	if(pgroup) {
 		for(auto& _pcard : pgroup->container)
 			newgroup->container.erase(_pcard);
@@ -731,6 +724,10 @@ LUA_FUNCTION(__le) {
 	check_param_count(L, 2);
 	auto sgroup = lua_get<group*, true>(L, 2);
 	lua_pushboolean(L, self->container.size() <= sgroup->container.size());
+	return 1;
+}
+LUA_FUNCTION(__gc) {
+	pduel->delete_group_no_unref(self);
 	return 1;
 }
 LUA_FUNCTION(IsContains) {

--- a/lua_obj.h
+++ b/lua_obj.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
+ * Copyright (c) 2020-2025, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -21,14 +21,93 @@ enum class LuaParam : uint8_t {
 };
 
 class duel;
+template<typename T>
+class owned_lua;
 
 class lua_obj {
+	template<typename T>
+	friend class owned_lua;
 public:
 	duel* pduel{ nullptr };
 	int32_t ref_handle{};
+	int32_t weak_ref_handle{};
 	LuaParam lua_type;
 protected:
 	lua_obj(LuaParam _lua_type, duel* _pduel) :pduel(_pduel), lua_type(_lua_type) {}
+private:
+	int num_ref{};
+	void incr_ref();
+	void decr_ref();
+};
+
+template<typename T>
+class owned_lua {
+	T* obj{};
+public:
+	using lua_type = T*;
+	owned_lua() = default;
+	owned_lua(T* obj_) : obj(obj_) {
+		if(obj) {
+			obj->incr_ref();
+		}
+	}
+	owned_lua(const owned_lua<T>& other) : obj(other.obj) {
+		if(obj) {
+			obj->incr_ref();
+		}
+	}
+	owned_lua(owned_lua<T>&& other) : obj(other.obj) {
+		other.obj = nullptr;
+	}
+	~owned_lua() {
+		if(obj) {
+			obj->decr_ref();
+		}
+	}
+	owned_lua<T>& operator=(const owned_lua<T>& other) {
+		if(obj) {
+			obj->decr_ref();
+		}
+		if(obj = other.obj; obj) {
+			obj->incr_ref();
+		}
+		return *this;
+	}
+	owned_lua<T>& operator=(owned_lua<T>&& other) {
+		if(obj) {
+			obj->decr_ref();
+		}
+		obj = other.obj;
+		other.obj = nullptr;
+		return *this;
+	}
+	owned_lua<T>& operator=(T* rhs) {
+		if(obj) {
+			obj->decr_ref();
+		}
+		if(obj = rhs; obj) {
+			obj->incr_ref();
+		}
+		return *this;
+	}
+	operator T* () const {
+		return obj;
+	}
+	operator T* () {
+		return obj;
+	}
+	T* operator-> () const {
+		return obj;
+	}
+	T* operator-> () {
+		return obj;
+	}
+	explicit operator bool() {
+		return obj != nullptr;
+	}
+	explicit operator bool() const {
+		return obj != nullptr;
+	}
 };
 
 template<LuaParam _Type>

--- a/lua_obj.h
+++ b/lua_obj.h
@@ -108,6 +108,12 @@ public:
 	bool operator ==(const owned_lua<T>& other) const {
 		return obj == other.obj;
 	}
+	bool operator <(const owned_lua<T>& other) {
+		return obj < other.obj;
+	}
+	bool operator <(const owned_lua<T>& other) const {
+		return obj < other.obj;
+	}
 	explicit operator bool() {
 		return obj != nullptr;
 	}

--- a/lua_obj.h
+++ b/lua_obj.h
@@ -102,6 +102,12 @@ public:
 	T* operator-> () {
 		return obj;
 	}
+	bool operator ==(const owned_lua<T>& other) {
+		return obj == other.obj;
+	}
+	bool operator ==(const owned_lua<T>& other) const {
+		return obj == other.obj;
+	}
 	explicit operator bool() {
 		return obj != nullptr;
 	}

--- a/operations.cpp
+++ b/operations.cpp
@@ -4564,7 +4564,7 @@ bool field::process(Processors::SendTo& arg) {
 			param->leave_field.insert(pcard);
 		}
 		if(param->predirect->operation) {
-			tevent e;
+			tevent e{};
 			e.event_cards = targets;
 			e.event_player = pcard->current.controler;
 			e.event_value = 0;

--- a/operations.cpp
+++ b/operations.cpp
@@ -1170,7 +1170,6 @@ bool field::process(Processors::GetControl& arg) {
 	case 7: {
 		core.operated_set = targets->container;
 		returns.set<int32_t>(0, static_cast<int32_t>(targets->container.size()));
-		pduel->delete_group(targets);
 		return TRUE;
 	}
 	}
@@ -1323,15 +1322,11 @@ bool field::process(Processors::SwapControl& arg) {
 	case 5: {
 		core.operated_set = targets1->container;
 		returns.set<int32_t>(0, 1);
-		pduel->delete_group(targets1);
-		pduel->delete_group(targets2);
 		return TRUE;
 	}
 	case 10: {
 		core.operated_set.clear();
 		returns.set<int32_t>(0, 0);
-		pduel->delete_group(targets1);
-		pduel->delete_group(targets2);
 		return TRUE;
 	}
 	}
@@ -3073,14 +3068,8 @@ bool field::process(Processors::SpSummonRule& arg) {
 		return FALSE;
 	}
 	case 4: {
-		if(core.must_use_mats) {
-			pduel->delete_group(core.must_use_mats);
-			core.must_use_mats = nullptr;
-		}
-		if(core.only_use_mats) {
-			pduel->delete_group(core.only_use_mats);
-			core.only_use_mats = nullptr;
-		}
+		core.must_use_mats = nullptr;
+		core.only_use_mats = nullptr;
 		auto proc = arg.summon_proc_effect;
 		uint8_t targetplayer = sumplayer;
 		uint8_t positions = POS_FACEUP;
@@ -3681,7 +3670,6 @@ bool field::process(Processors::SpSummon& arg) {
 		if(targets->container.size() == 0) {
 			returns.set<int32_t>(0, 0);
 			core.operated_set.clear();
-			pduel->delete_group(targets);
 			return TRUE;
 		}
 		bool tp = false, ntp = false;
@@ -3749,7 +3737,6 @@ bool field::process(Processors::SpSummon& arg) {
 		core.operated_set.clear();
 		core.operated_set = targets->container;
 		returns.set<int32_t>(0, static_cast<int32_t>(targets->container.size()));
-		pduel->delete_group(targets);
 		return TRUE;
 	}
 	}
@@ -3936,7 +3923,6 @@ bool field::process(Processors::Destroy& arg) {
 		if(!targets->container.size()) {
 			returns.set<int32_t>(0, 0);
 			core.operated_set.clear();
-			pduel->delete_group(targets);
 			return TRUE;
 		}
 		card_vector cv(targets->container.begin(), targets->container.end());
@@ -3988,7 +3974,6 @@ bool field::process(Processors::Destroy& arg) {
 				++cit;
 		}
 		returns.set<int32_t>(0, static_cast<int32_t>(core.operated_set.size()));
-		pduel->delete_group(targets);
 		return TRUE;
 	}
 	case 10: {
@@ -4174,7 +4159,6 @@ bool field::process(Processors::Release& arg) {
 		if(!targets->container.size()) {
 			returns.set<int32_t>(0, 0);
 			core.operated_set.clear();
-			pduel->delete_group(targets);
 			return TRUE;
 		}
 		card_vector cv(targets->container.begin(), targets->container.end());
@@ -4213,7 +4197,6 @@ bool field::process(Processors::Release& arg) {
 		core.operated_set.clear();
 		core.operated_set = targets->container;
 		returns.set<int32_t>(0, static_cast<int32_t>(targets->container.size()));
-		pduel->delete_group(targets);
 		return TRUE;
 	}
 	}
@@ -4283,7 +4266,6 @@ bool field::process(Processors::SendTo& arg) {
 		if(!targets->container.size()) {
 			returns.set<int32_t>(0, 0);
 			core.operated_set.clear();
-			pduel->delete_group(targets);
 			return TRUE;
 		}
 		card_set leave_p, destroying;
@@ -4739,7 +4721,6 @@ bool field::process(Processors::SendTo& arg) {
 		core.operated_set.clear();
 		core.operated_set = targets->container;
 		returns.set<int32_t>(0, static_cast<int32_t>(targets->container.size()));
-		pduel->delete_group(targets);
 		return TRUE;
 	}
 	}
@@ -5356,7 +5337,6 @@ bool field::process(Processors::ChangePos& arg) {
 		core.operated_set.clear();
 		core.operated_set = targets->container;
 		returns.set<int32_t>(0, static_cast<int32_t>(targets->container.size()));
-		pduel->delete_group(targets);
 		return TRUE;
 	}
 	}
@@ -5422,12 +5402,6 @@ bool field::process(Processors::OperationReplace& arg) {
 		return FALSE;
 	}
 	case 3: {
-		if(core.continuous_chain.back().target_cards)
-			pduel->delete_group(core.continuous_chain.back().target_cards);
-		for(auto& oit : core.continuous_chain.back().opinfos) {
-			if(oit.second.op_cards)
-				pduel->delete_group(oit.second.op_cards);
-		}
 		core.continuous_chain.pop_back();
 		core.solving_event.pop_front();
 		return TRUE;
@@ -5488,12 +5462,6 @@ bool field::process(Processors::OperationReplace& arg) {
 		return FALSE;
 	}
 	case 8: {
-		if(core.continuous_chain.back().target_cards)
-			pduel->delete_group(core.continuous_chain.back().target_cards);
-		for(auto& oit : core.continuous_chain.back().opinfos) {
-			if(oit.second.op_cards)
-				pduel->delete_group(oit.second.op_cards);
-		}
 		core.continuous_chain.pop_back();
 		core.solving_event.pop_front();
 		return TRUE;
@@ -5602,12 +5570,6 @@ bool field::process(Processors::OperationReplace& arg) {
 		return FALSE;
 	}
 	case 16: {
-		if(core.continuous_chain.back().target_cards)
-			pduel->delete_group(core.continuous_chain.back().target_cards);
-		for(auto& oit : core.continuous_chain.back().opinfos) {
-			if(oit.second.op_cards)
-				pduel->delete_group(oit.second.op_cards);
-		}
 		core.continuous_chain.pop_back();
 		arg.step = 14;
 		return FALSE;

--- a/operations.cpp
+++ b/operations.cpp
@@ -81,7 +81,7 @@ void field::change_target(uint8_t chaincount, group* targets) {
 		return;
 	if(chaincount > core.current_chain.size() || chaincount < 1)
 		chaincount = static_cast<uint8_t>(core.current_chain.size());
-	group* ot = core.current_chain[chaincount - 1].target_cards;
+	auto ot = core.current_chain[chaincount - 1].target_cards;
 	if(ot) {
 		effect* te = core.current_chain[chaincount - 1].triggering_effect;
 		for(auto& pcard : ot->container)
@@ -119,7 +119,7 @@ void field::remove_overlay_card(uint32_t reason, group* pgroup, uint32_t rplayer
 	emplace_process<Processors::RemoveOverlay>(reason, pgroup, rplayer, self, oppo, min, max);
 }
 void field::xyz_overlay(card* target, card_set materials, bool send_materials_to_grave) {
-	group* ng = pduel->new_group(std::move(materials));
+	auto ng = pduel->new_group(std::move(materials));
 	ng->is_readonly = TRUE;
 	emplace_process<Processors::XyzOverlay>(target, ng, send_materials_to_grave);
 }
@@ -127,7 +127,7 @@ void field::xyz_overlay(card* target, card* material, bool send_materials_to_gra
 	xyz_overlay(target, card_set{ material }, send_materials_to_grave);
 }
 void field::get_control(card_set targets, effect* reason_effect, uint8_t chose_player, uint8_t playerid, uint16_t reset_phase, uint8_t reset_count, uint32_t zone) {
-	group* ng = pduel->new_group(std::move(targets));
+	auto ng = pduel->new_group(std::move(targets));
 	ng->is_readonly = TRUE;
 	emplace_process<Processors::GetControl>(reason_effect, chose_player, ng, playerid, reset_phase, reset_count, zone);
 }
@@ -135,9 +135,9 @@ void field::get_control(card* target, effect* reason_effect, uint8_t chose_playe
 	get_control(card_set{ target }, reason_effect, chose_player, playerid, reset_phase, reset_count, zone);
 }
 void field::swap_control(effect* reason_effect, uint32_t reason_player, card_set targets1, card_set targets2, uint32_t reset_phase, uint32_t reset_count) {
-	group* ng1 = pduel->new_group(std::move(targets1));
+	auto ng1 = pduel->new_group(std::move(targets1));
 	ng1->is_readonly = TRUE;
-	group* ng2 = pduel->new_group(std::move(targets2));
+	auto ng2 = pduel->new_group(std::move(targets2));
 	ng2->is_readonly = TRUE;
 	emplace_process<Processors::SwapControl>(reason_effect, reason_player, ng1, ng2, reset_phase, reset_count);
 }
@@ -206,7 +206,7 @@ void field::special_summon(card_set target, uint32_t sumtype, uint8_t sumplayer,
 		}
 		pcard->spsummon_param = (playerid << 24) + (nocheck << 16) + (nolimit << 8) + pos;
 	}
-	group* pgroup = pduel->new_group(std::move(target));
+	auto pgroup = pduel->new_group(std::move(target));
 	pgroup->is_readonly = TRUE;
 	emplace_process<Processors::SpSummon>(core.reason_effect, core.reason_player, pgroup, zone);
 }
@@ -246,8 +246,8 @@ void field::special_summon_step(card* target, uint32_t sumtype, uint8_t sumplaye
 	emplace_process<Processors::SpSummonStep>(nullptr, target, zone);
 }
 void field::special_summon_complete(effect* reason_effect, uint8_t reason_player) {
-	group* ng = pduel->new_group();
-	ng->container.swap(core.special_summoning);
+	auto ng = pduel->new_group(std::move(core.special_summoning));
+	core.special_summoning.clear();
 	ng->is_readonly = TRUE;
 	emplace_process<Processors::SpSummon>(Step{ 1 }, reason_effect, reason_player, ng, 0);
 }
@@ -279,7 +279,7 @@ void field::destroy(card_set targets, effect* reason_effect, uint32_t reason, ui
 		pcard->sendto_param.set(p, POS_FACEUP, destination, sequence);
 		++cit;
 	}
-	group* ng = pduel->new_group(std::move(targets));
+	auto ng = pduel->new_group(std::move(targets));
 	ng->is_readonly = TRUE;
 	emplace_process<Processors::Destroy>(ng, reason_effect, reason, reason_player);
 }
@@ -296,7 +296,7 @@ void field::release(card_set targets, effect* reason_effect, uint32_t reason, ui
 		pcard->current.reason_player = reason_player;
 		pcard->sendto_param.set(pcard->owner, POS_FACEUP, LOCATION_GRAVE);
 	}
-	group* ng = pduel->new_group(std::move(targets));
+	auto ng = pduel->new_group(std::move(targets));
 	ng->is_readonly = TRUE;
 	emplace_process<Processors::Release>(ng, reason_effect, reason, reason_player);
 }
@@ -330,7 +330,7 @@ void field::send_to(card_set targets, effect* reason_effect, uint32_t reason, ui
 			pos = pcard->current.position;
 		pcard->sendto_param.set(p, pos, destination, sequence);
 	}
-	group* ng = pduel->new_group(std::move(targets));
+	auto ng = pduel->new_group(std::move(targets));
 	ng->is_readonly = TRUE;
 	emplace_process<Processors::SendTo>(ng, reason_effect, reason, reason_player);
 }
@@ -369,7 +369,7 @@ void field::move_to_field(card* target, uint8_t move_player, uint8_t playerid, u
 	emplace_process<Processors::MoveToField>(target, enable, ret, pzone, zone, rule, reason, confirm);
 }
 void field::change_position(card_set targets, effect* reason_effect, uint8_t reason_player, uint8_t au, uint8_t ad, uint8_t du, uint8_t dd, uint32_t flag, bool enable) {
-	group* ng = pduel->new_group(std::move(targets));
+	auto ng = pduel->new_group(std::move(targets));
 	ng->is_readonly = TRUE;
 	for(auto& pcard : ng->container) {
 		if(pcard->current.position == POS_FACEUP_ATTACK)
@@ -385,7 +385,7 @@ void field::change_position(card_set targets, effect* reason_effect, uint8_t rea
 	emplace_process<Processors::ChangePos>(ng, reason_effect, reason_player, enable);
 }
 void field::change_position(card* target, effect* reason_effect, uint8_t reason_player, uint8_t npos, uint32_t flag, bool enable) {
-	group* ng = pduel->new_group(target);
+	auto ng = pduel->new_group(target);
 	ng->is_readonly = TRUE;
 	target->position_param = npos;
 	target->position_param |= flag;
@@ -2995,8 +2995,8 @@ bool field::process(Processors::SpSummonRule& arg) {
 	switch(arg.step) {
 	case 0: {
 		effect_set eset;
-		group* must_mats = core.must_use_mats;
-		group* materials = core.only_use_mats;
+		auto must_mats = core.must_use_mats;
+		auto materials = core.only_use_mats;
 		int32_t minc = core.forced_summon_minc;
 		int32_t maxc = core.forced_summon_maxc;
 		target->filter_spsummon_procedure(sumplayer, &eset, summon_type);
@@ -3271,7 +3271,7 @@ bool field::process(Processors::SpSummonRule& arg) {
 		return FALSE;
 	}
 	case 21: {
-		group* pgroup = arg.cards_to_summon_g;
+		auto pgroup = arg.cards_to_summon_g;
 		for(auto cit = pgroup->container.begin(); cit != pgroup->container.end(); ) {
 			card* pcard = *cit++;
 			if(!(pcard->data.type & TYPE_MONSTER)
@@ -3293,7 +3293,7 @@ bool field::process(Processors::SpSummonRule& arg) {
 		return FALSE;
 	}
 	case 22: {
-		group* pgroup = arg.cards_to_summon_g;
+		auto pgroup = arg.cards_to_summon_g;
 		if(pgroup->container.size() == 0)
 			return TRUE;
 		core.phase_action = true;
@@ -3302,7 +3302,7 @@ bool field::process(Processors::SpSummonRule& arg) {
 	}
 	case 23: {
 		auto proc = arg.summon_proc_effect;
-		group* pgroup = arg.cards_to_summon_g;
+		auto pgroup = arg.cards_to_summon_g;
 		card* pcard = *pgroup->it;
 		pcard->enable_field_effect(false);
 		pcard->current.reason = REASON_SPSUMMON;
@@ -3355,7 +3355,7 @@ bool field::process(Processors::SpSummonRule& arg) {
 		return FALSE;
 	}
 	case 24: {
-		group* pgroup = arg.cards_to_summon_g;
+		auto pgroup = arg.cards_to_summon_g;
 		card* pcard = *pgroup->it++;
 		auto message = pduel->new_message(MSG_SPSUMMONING);
 		message->write<uint32_t>(pcard->data.code);
@@ -3367,7 +3367,7 @@ bool field::process(Processors::SpSummonRule& arg) {
 		return FALSE;
 	}
 	case 25: {
-		group* pgroup = arg.cards_to_summon_g; 
+		auto pgroup = arg.cards_to_summon_g;
 		if(is_flag(DUEL_CANNOT_SUMMON_OATH_OLD)) {
 			set_spsummon_counter(sumplayer);
 		}
@@ -3402,7 +3402,7 @@ bool field::process(Processors::SpSummonRule& arg) {
 		return FALSE;
 	}
 	case 26: {
-		group* pgroup = arg.cards_to_summon_g;
+		auto pgroup = arg.cards_to_summon_g;
 		card_set cset;
 		for(auto cit = pgroup->container.begin(); cit != pgroup->container.end(); ) {
 			card* pcard = *cit++;
@@ -3432,7 +3432,7 @@ bool field::process(Processors::SpSummonRule& arg) {
 		return FALSE;
 	}
 	case 27: {
-		group* pgroup = arg.cards_to_summon_g;
+		auto pgroup = arg.cards_to_summon_g;
 		release_oath_relation(arg.summon_proc_effect);
 		for(const auto& peffect : arg.spsummon_cost_effects)
 			release_oath_relation(peffect);
@@ -3446,7 +3446,7 @@ bool field::process(Processors::SpSummonRule& arg) {
 		return FALSE;
 	}
 	case 28: {
-		group* pgroup = arg.cards_to_summon_g;
+		auto pgroup = arg.cards_to_summon_g;
 		pduel->new_message(MSG_SPSUMMONED);
 		if(!is_flag(DUEL_CANNOT_SUMMON_OATH_OLD)) {
 			set_spsummon_counter(sumplayer);
@@ -3961,7 +3961,7 @@ bool field::process(Processors::Destroy& arg) {
 		return FALSE;
 	}
 	case 4: {
-		group* sendtargets = pduel->new_group(targets->container);
+		auto sendtargets = pduel->new_group(targets->container);
 		sendtargets->is_readonly = TRUE;
 		for(auto& pcard : sendtargets->container) {
 			pcard->set_status(STATUS_DESTROY_CONFIRMED, FALSE);
@@ -4200,7 +4200,7 @@ bool field::process(Processors::Release& arg) {
 			message->write<uint8_t>(0);
 			message->write<uint64_t>(peffect->get_handler()->data.code);
 		}
-		group* sendtargets = pduel->new_group(targets->container);
+		auto sendtargets = pduel->new_group(targets->container);
 		sendtargets->is_readonly = TRUE;
 		operation_replace(EFFECT_SEND_REPLACE, 5, sendtargets);
 		emplace_process<Processors::SendTo>(Step{ 1 }, sendtargets, reason_effect, reason | REASON_RELEASE, reason_player);

--- a/operations.cpp
+++ b/operations.cpp
@@ -120,7 +120,7 @@ void field::remove_overlay_card(uint32_t reason, group* pgroup, uint32_t rplayer
 }
 void field::xyz_overlay(card* target, card_set materials, bool send_materials_to_grave) {
 	auto ng = pduel->new_group(std::move(materials));
-	ng->is_readonly = TRUE;
+	ng->is_readonly = true;
 	emplace_process<Processors::XyzOverlay>(target, ng, send_materials_to_grave);
 }
 void field::xyz_overlay(card* target, card* material, bool send_materials_to_grave) {
@@ -128,7 +128,7 @@ void field::xyz_overlay(card* target, card* material, bool send_materials_to_gra
 }
 void field::get_control(card_set targets, effect* reason_effect, uint8_t chose_player, uint8_t playerid, uint16_t reset_phase, uint8_t reset_count, uint32_t zone) {
 	auto ng = pduel->new_group(std::move(targets));
-	ng->is_readonly = TRUE;
+	ng->is_readonly = true;
 	emplace_process<Processors::GetControl>(reason_effect, chose_player, ng, playerid, reset_phase, reset_count, zone);
 }
 void field::get_control(card* target, effect* reason_effect, uint8_t chose_player, uint8_t playerid, uint16_t reset_phase, uint8_t reset_count, uint32_t zone) {
@@ -136,9 +136,9 @@ void field::get_control(card* target, effect* reason_effect, uint8_t chose_playe
 }
 void field::swap_control(effect* reason_effect, uint32_t reason_player, card_set targets1, card_set targets2, uint32_t reset_phase, uint32_t reset_count) {
 	auto ng1 = pduel->new_group(std::move(targets1));
-	ng1->is_readonly = TRUE;
+	ng1->is_readonly = true;
 	auto ng2 = pduel->new_group(std::move(targets2));
-	ng2->is_readonly = TRUE;
+	ng2->is_readonly = true;
 	emplace_process<Processors::SwapControl>(reason_effect, reason_player, ng1, ng2, reset_phase, reset_count);
 }
 void field::swap_control(effect* reason_effect, uint32_t reason_player, card* pcard1, card* pcard2, uint32_t reset_phase, uint32_t reset_count) {
@@ -207,7 +207,7 @@ void field::special_summon(card_set target, uint32_t sumtype, uint8_t sumplayer,
 		pcard->spsummon_param = (playerid << 24) + (nocheck << 16) + (nolimit << 8) + pos;
 	}
 	auto pgroup = pduel->new_group(std::move(target));
-	pgroup->is_readonly = TRUE;
+	pgroup->is_readonly = true;
 	emplace_process<Processors::SpSummon>(core.reason_effect, core.reason_player, pgroup, zone);
 }
 void field::special_summon_step(card* target, uint32_t sumtype, uint8_t sumplayer, uint8_t playerid, bool nocheck, bool nolimit, uint8_t positions, uint32_t zone) {
@@ -248,7 +248,7 @@ void field::special_summon_step(card* target, uint32_t sumtype, uint8_t sumplaye
 void field::special_summon_complete(effect* reason_effect, uint8_t reason_player) {
 	auto ng = pduel->new_group(std::move(core.special_summoning));
 	core.special_summoning.clear();
-	ng->is_readonly = TRUE;
+	ng->is_readonly = true;
 	emplace_process<Processors::SpSummon>(Step{ 1 }, reason_effect, reason_player, ng, 0);
 }
 void field::destroy(card_set targets, effect* reason_effect, uint32_t reason, uint8_t reason_player, uint8_t playerid, uint16_t destination, uint32_t sequence) {
@@ -280,7 +280,7 @@ void field::destroy(card_set targets, effect* reason_effect, uint32_t reason, ui
 		++cit;
 	}
 	auto ng = pduel->new_group(std::move(targets));
-	ng->is_readonly = TRUE;
+	ng->is_readonly = true;
 	emplace_process<Processors::Destroy>(ng, reason_effect, reason, reason_player);
 }
 void field::destroy(card* target, effect* reason_effect, uint32_t reason, uint8_t reason_player, uint8_t playerid, uint16_t destination, uint32_t sequence) {
@@ -297,7 +297,7 @@ void field::release(card_set targets, effect* reason_effect, uint32_t reason, ui
 		pcard->sendto_param.set(pcard->owner, POS_FACEUP, LOCATION_GRAVE);
 	}
 	auto ng = pduel->new_group(std::move(targets));
-	ng->is_readonly = TRUE;
+	ng->is_readonly = true;
 	emplace_process<Processors::Release>(ng, reason_effect, reason, reason_player);
 }
 void field::release(card* target, effect* reason_effect, uint32_t reason, uint8_t reason_player) {
@@ -331,7 +331,7 @@ void field::send_to(card_set targets, effect* reason_effect, uint32_t reason, ui
 		pcard->sendto_param.set(p, pos, destination, sequence);
 	}
 	auto ng = pduel->new_group(std::move(targets));
-	ng->is_readonly = TRUE;
+	ng->is_readonly = true;
 	emplace_process<Processors::SendTo>(ng, reason_effect, reason, reason_player);
 }
 void field::send_to(card* target, effect* reason_effect, uint32_t reason, uint8_t reason_player, uint8_t playerid, uint16_t destination, uint32_t sequence, uint8_t position, bool ignore) {
@@ -370,7 +370,7 @@ void field::move_to_field(card* target, uint8_t move_player, uint8_t playerid, u
 }
 void field::change_position(card_set targets, effect* reason_effect, uint8_t reason_player, uint8_t au, uint8_t ad, uint8_t du, uint8_t dd, uint32_t flag, bool enable) {
 	auto ng = pduel->new_group(std::move(targets));
-	ng->is_readonly = TRUE;
+	ng->is_readonly = true;
 	for(auto& pcard : ng->container) {
 		if(pcard->current.position == POS_FACEUP_ATTACK)
 			pcard->position_param = au;
@@ -386,7 +386,7 @@ void field::change_position(card_set targets, effect* reason_effect, uint8_t rea
 }
 void field::change_position(card* target, effect* reason_effect, uint8_t reason_player, uint8_t npos, uint32_t flag, bool enable) {
 	auto ng = pduel->new_group(target);
-	ng->is_readonly = TRUE;
+	ng->is_readonly = true;
 	target->position_param = npos;
 	target->position_param |= flag;
 	emplace_process<Processors::ChangePos>(ng, reason_effect, reason_player, enable);
@@ -3962,7 +3962,7 @@ bool field::process(Processors::Destroy& arg) {
 	}
 	case 4: {
 		auto sendtargets = pduel->new_group(targets->container);
-		sendtargets->is_readonly = TRUE;
+		sendtargets->is_readonly = true;
 		for(auto& pcard : sendtargets->container) {
 			pcard->set_status(STATUS_DESTROY_CONFIRMED, FALSE);
 			uint32_t dest = pcard->sendto_param.location;
@@ -4201,7 +4201,7 @@ bool field::process(Processors::Release& arg) {
 			message->write<uint64_t>(peffect->get_handler()->data.code);
 		}
 		auto sendtargets = pduel->new_group(targets->container);
-		sendtargets->is_readonly = TRUE;
+		sendtargets->is_readonly = true;
 		operation_replace(EFFECT_SEND_REPLACE, 5, sendtargets);
 		emplace_process<Processors::SendTo>(Step{ 1 }, sendtargets, reason_effect, reason | REASON_RELEASE, reason_player);
 		return FALSE;

--- a/processor.cpp
+++ b/processor.cpp
@@ -198,7 +198,7 @@ void field::raise_event(card* event_card, uint32_t event_code, effect* reason_ef
 	new_event.trigger_card = nullptr;
 	if (event_card) {
 		auto pgroup = pduel->new_group(event_card);
-		pgroup->is_readonly = TRUE;
+		pgroup->is_readonly = true;
 		new_event.event_cards = pgroup;
 	} else
 		new_event.event_cards = nullptr;
@@ -214,7 +214,7 @@ void field::raise_event(card_set event_cards, uint32_t event_code, effect* reaso
 	auto& new_event = core.queue_event.emplace_back();
 	new_event.trigger_card = nullptr;
 	auto pgroup = pduel->new_group(std::move(event_cards));
-	pgroup->is_readonly = TRUE;
+	pgroup->is_readonly = true;
 	new_event.event_cards = pgroup;
 	new_event.event_code = event_code;
 	new_event.reason_effect = reason_effect;
@@ -229,7 +229,7 @@ void field::raise_single_event(card* trigger_card, card_set* event_cards, uint32
 	new_event.trigger_card = trigger_card;
 	if (event_cards) {
 		auto pgroup = pduel->new_group(*event_cards);
-		pgroup->is_readonly = TRUE;
+		pgroup->is_readonly = true;
 		new_event.event_cards = pgroup;
 	} else
 		new_event.event_cards = nullptr;
@@ -2556,7 +2556,7 @@ bool field::process(Processors::BattleCommand& arg) {
 		if(des.size()) {
 			auto ng = pduel->new_group();
 			ng->container.swap(des);
-			ng->is_readonly = TRUE;
+			ng->is_readonly = true;
 			emplace_process<Processors::Destroy>(Step{ 10 }, ng, nullptr, REASON_BATTLE, PLAYER_NONE);
 			arg.cards_destroyed_by_battle = ng;
 		}
@@ -4901,7 +4901,7 @@ bool field::process(Processors::Adjust& arg) {
 			core.re_adjust = true;
 			auto ng = pduel->new_group();
 			ng->container.swap(pos_adjust);
-			ng->is_readonly = TRUE;
+			ng->is_readonly = true;
 			emplace_process<Processors::ChangePos>(ng, nullptr, PLAYER_NONE, true);
 		}
 		return FALSE;

--- a/processor.cpp
+++ b/processor.cpp
@@ -3255,10 +3255,6 @@ bool field::process(Processors::Turn& arg) {
 	switch(arg.step) {
 	case 0: {
 		//Pre Draw
-		for(const auto& ev : core.used_event) {
-			if(ev.event_cards)
-				pduel->delete_group(ev.event_cards);
-		}
 		core.used_event.clear();
 		for(auto& peffect : core.reseted_effects) {
 			pduel->delete_effect(peffect);
@@ -4052,12 +4048,6 @@ bool field::process(Processors::SolveContinuous& arg) {
 		effect* peffect = clit.triggering_effect;
 		core.reason_effect = arg.reason_effect;
 		core.reason_player = arg.reason_player;
-		if(core.continuous_chain.back().target_cards)
-			pduel->delete_group(core.continuous_chain.back().target_cards);
-		for(auto& oit : core.continuous_chain.back().opinfos) {
-			if(oit.second.op_cards)
-				pduel->delete_group(oit.second.op_cards);
-		}
 		core.continuous_chain.pop_back();
 		core.solving_continuous.pop_front();
 		if(peffect->is_flag(EFFECT_FLAG_DELAY) || (!(peffect->code & 0xfffff000u) && (peffect->code & (EVENT_PHASE | EVENT_PHASE_START)))) {
@@ -4308,12 +4298,6 @@ bool field::process(Processors::SolveChain& arg) {
 		peffect->active_type = 0;
 		peffect->active_handler = nullptr;
 		pcard->release_relation(*cait);
-		if(cait->target_cards)
-			pduel->delete_group(cait->target_cards);
-		for(auto& oit : cait->opinfos) {
-			if(oit.second.op_cards)
-				pduel->delete_group(oit.second.op_cards);
-		}
 		for(auto& cit : core.delayed_enable_set) {
 			if(cit->current.location == LOCATION_MZONE)
 				cit->enable_field_effect(true);

--- a/processor.cpp
+++ b/processor.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010-2015, Argon Sun (Fluorohydride)
- * Copyright (c) 2016-2024, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
+ * Copyright (c) 2016-2025, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -197,7 +197,7 @@ void field::raise_event(card* event_card, uint32_t event_code, effect* reason_ef
 	auto& new_event = core.queue_event.emplace_back();
 	new_event.trigger_card = nullptr;
 	if (event_card) {
-		group* pgroup = pduel->new_group(event_card);
+		auto pgroup = pduel->new_group(event_card);
 		pgroup->is_readonly = TRUE;
 		new_event.event_cards = pgroup;
 	} else
@@ -213,7 +213,7 @@ void field::raise_event(card* event_card, uint32_t event_code, effect* reason_ef
 void field::raise_event(card_set event_cards, uint32_t event_code, effect* reason_effect, uint32_t reason, uint8_t reason_player, uint8_t event_player, uint32_t event_value) {
 	auto& new_event = core.queue_event.emplace_back();
 	new_event.trigger_card = nullptr;
-	group* pgroup = pduel->new_group(std::move(event_cards));
+	auto pgroup = pduel->new_group(std::move(event_cards));
 	pgroup->is_readonly = TRUE;
 	new_event.event_cards = pgroup;
 	new_event.event_code = event_code;
@@ -228,7 +228,7 @@ void field::raise_single_event(card* trigger_card, card_set* event_cards, uint32
 	auto& new_event = core.single_event.emplace_back();
 	new_event.trigger_card = trigger_card;
 	if (event_cards) {
-		group* pgroup = pduel->new_group(*event_cards);
+		auto pgroup = pduel->new_group(*event_cards);
 		pgroup->is_readonly = TRUE;
 		new_event.event_cards = pgroup;
 	} else
@@ -2554,7 +2554,7 @@ bool field::process(Processors::BattleCommand& arg) {
 		core.battle_destroy_rep.clear();
 		core.desrep_chain.clear();
 		if(des.size()) {
-			group* ng = pduel->new_group();
+			auto ng = pduel->new_group();
 			ng->container.swap(des);
 			ng->is_readonly = TRUE;
 			emplace_process<Processors::Destroy>(Step{ 10 }, ng, nullptr, REASON_BATTLE, PLAYER_NONE);
@@ -2571,7 +2571,7 @@ bool field::process(Processors::BattleCommand& arg) {
 		return FALSE;
 	}
 	case 30: {
-		group* des = arg.cards_destroyed_by_battle;
+		auto des = arg.cards_destroyed_by_battle;
 		if(des && des->container.size()) {
 			for(auto& pcard : des->container) {
 				pcard->set_status(STATUS_BATTLE_DESTROYED, TRUE);
@@ -2636,7 +2636,7 @@ bool field::process(Processors::BattleCommand& arg) {
 		return FALSE;
 	}
 	case 33: {
-		group* des = arg.cards_destroyed_by_battle;
+		auto des = arg.cards_destroyed_by_battle;
 		if(des) {
 			for(auto cit = des->container.begin(); cit != des->container.end();) {
 				auto rm = cit++;
@@ -4899,7 +4899,7 @@ bool field::process(Processors::Adjust& arg) {
 		}
 		if(pos_adjust.size()) {
 			core.re_adjust = true;
-			group* ng = pduel->new_group();
+			auto ng = pduel->new_group();
 			ng->container.swap(pos_adjust);
 			ng->is_readonly = TRUE;
 			emplace_process<Processors::ChangePos>(ng, nullptr, PLAYER_NONE, true);

--- a/scriptlib.cpp
+++ b/scriptlib.cpp
@@ -58,11 +58,11 @@ int32_t push_return_cards(lua_State* L, int32_t/* status*/, lua_KContext ctx) {
 		if(cancelable) {
 			lua_pushnil(L);
 		} else {
-			group* pgroup = pduel->new_group();
+			auto pgroup = pduel->new_group();
 			interpreter::pushobject(L, pgroup);
 		}
 	} else {
-		group* pgroup = pduel->new_group(pduel->game_field->return_cards.list);
+		auto pgroup = pduel->new_group(pduel->game_field->return_cards.list);
 		interpreter::pushobject(L, pgroup);
 	}
 	return 1;

--- a/scriptlib.cpp
+++ b/scriptlib.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010-2015, Argon Sun (Fluorohydride)
- * Copyright (c) 2018-2024, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
+ * Copyright (c) 2018-2025, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */


### PR DESCRIPTION
No longer manage groups lifetimes explicitly in the core, but leverage lua's garbage collector to handle their lifetime.
In this change, groups will be stored internally in the core inside a weak table, so that they will still be referenceable when needed, but if no reference were to exist in lua code, they will be subject to garbage collection.
Whenever a group is used internally by the core, it's wrapped by an `owned_lua` object, this object is akin to a smart pointer, reference counting the usages of that group internally in the core, including registering and unregistering it in the lua registry index when in use, so that it won't be collected.
With this approach, the exponential memory usage growth caused by long running procedure functions creating hundredths of thousands of groups per iteration is mitigated, since the temporary groups will be reaped more frequently rather than with the old approach of them being cleared only after the topmost lua function had finished executing. For now a single gc step is triggered whenever the total number of groups is more than 2000, an arbitrary value that seems to work well enough, but which can be changed after proper investigation.
A major upgrade with this approach, is the removal of the concept of groups "kept alive" and having to "explicitly delete" them to make them outlive a lua function execution, since they will now follow lua variables lifetime properly.