### PR TITLE
Add ocgapi callback to check if a set of opcodes would allow for a card to be declred

### DIFF
--- a/duel.cpp
+++ b/duel.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010-2015, Argon Sun (Fluorohydride)
- * Copyright (c) 2017-2025, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
+ * Copyright (c) 2017-2026, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -16,8 +16,10 @@ duel::duel(const OCG_DuelOptions& options, bool& valid_lua_lib) :
 	random({ options.seed[0], options.seed[1], options.seed[2], options.seed[3] }),
 	read_card_callback(options.cardReader), read_script_callback(options.scriptReader),
 	handle_message_callback(options.logHandler), read_card_done_callback(options.cardReaderDone),
+	exist_cards_to_declare_callback(options.existCardsToDeclare),
 	read_card_payload(options.payload1), read_script_payload(options.payload2),
-	handle_message_payload(options.payload3), read_card_done_payload(options.payload4)
+	handle_message_payload(options.payload3), read_card_done_payload(options.payload4),
+	exist_cards_to_declare_payload(options.payload5)
 {
 	lua = new interpreter(this, options, valid_lua_lib);
 	if(!valid_lua_lib)

--- a/duel.h
+++ b/duel.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010-2015, Argon Sun (Fluorohydride)
- * Copyright (c) 2016-2025, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
+ * Copyright (c) 2016-2026, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -109,6 +109,13 @@ public:
 	inline int read_script(const char* name) {
 		return read_script_callback(read_script_payload, this, name);
 	}
+	inline int filter_allows_declaring_cards(const uint64_t* opcodes, size_t count){
+		return exist_cards_to_declare_callback(exist_cards_to_declare_payload, opcodes, count);
+	}
+	template<typename T>
+	inline int filter_allows_declaring_cards(const T& opcodes){
+		return filter_allows_declaring_cards(opcodes.data(), opcodes.size());
+	}
 private:
 	std::deque<duel_message> messages;
 	RNG::Xoshiro256StarStar random;
@@ -116,10 +123,12 @@ private:
 	OCG_ScriptReader read_script_callback;
 	OCG_LogHandler handle_message_callback;
 	OCG_DataReaderDone read_card_done_callback;
+	OCG_ExistCardsToDeclare exist_cards_to_declare_callback;
 	void* read_card_payload;
 	void* read_script_payload;
 	void* handle_message_payload;
 	void* read_card_done_payload;
+	void* exist_cards_to_declare_payload;
 };
 
 #endif /* DUEL_H_ */

--- a/libduel.cpp
+++ b/libduel.cpp
@@ -3367,28 +3367,26 @@ LUA_STATIC_FUNCTION(AnnounceNumberRange) {
 	});
 }
 LUA_FUNCTION_ALIAS(AnnounceLevel);
-LUA_STATIC_FUNCTION(AnnounceCard) {
-	check_action_permission(L);
-	check_param_count(L, 1);
-	auto playerid = lua_get<uint8_t>(L, 1);
-	auto& options = pduel->game_field->core.select_options;
-	pduel->game_field->core.select_options.clear();
-	if(auto paramcount = lua_gettop(L); paramcount > 2 || lua_istable(L, 2)) {
-		lua_iterate_table_or_stack(L, 2, paramcount, [&options, L] {
-			options.push_back(lua_get<uint64_t>(L, -1));
+void get_opcodes(lua_State* L, std::vector<uint64_t>& opcodes, int arguments_start) {
+	opcodes.reserve(lua_gettop(L));
+	if(auto paramcount = lua_gettop(L); paramcount > arguments_start || lua_istable(L, arguments_start)) {
+		lua_iterate_table_or_stack(L, arguments_start, paramcount, [&opcodes, L] {
+			opcodes.push_back(lua_get<uint64_t>(L, -1));
 		});
 	} else {
 		uint32_t ttype = TYPE_MONSTER | TYPE_SPELL | TYPE_TRAP;
-		if(paramcount == 2)
-			ttype = lua_get<uint32_t>(L, 2);
-		options.push_back(ttype);
-		options.push_back(OPCODE_ISTYPE);
+		if(paramcount == arguments_start)
+			ttype = lua_get<uint32_t>(L, arguments_start);
+		opcodes.push_back(ttype);
+		opcodes.push_back(OPCODE_ISTYPE);
 	}
+}
+bool check_announceable(const std::vector<uint64_t>& opcodes, bool& has_filter_opcodes){
 	int32_t stack_size = 0;
-	bool has_opcodes = false;
-	for(auto& opcode : options) {
+	has_filter_opcodes = false;
+	for(auto& opcode : opcodes) {
 		if(opcode != OPCODE_ALLOW_ALIASES && opcode != OPCODE_ALLOW_TOKENS)
-			has_opcodes = true;
+			has_filter_opcodes = true;
 		switch(opcode) {
 		case OPCODE_ADD:
 		case OPCODE_SUB:
@@ -3421,9 +3419,32 @@ LUA_STATIC_FUNCTION(AnnounceCard) {
 		if(stack_size <= 0)
 			break;
 	}
-	if(stack_size != 1 && has_opcodes)
+	return !(stack_size != 1 && has_filter_opcodes);
+}
+LUA_STATIC_FUNCTION(HasAnnounceableCard) {
+	std::vector<uint64_t> options;
+	get_opcodes(L, options, 1);
+	bool has_filter_opcodes = false;
+	if(!check_announceable(options, has_filter_opcodes))
 		lua_error(L, "Parameters are invalid.");
-	if(!has_opcodes) {
+	if(!has_filter_opcodes) {
+		options.push_back(TYPE_MONSTER | TYPE_SPELL | TYPE_TRAP);
+		options.push_back(OPCODE_ISTYPE);
+	}
+	lua_pushboolean(L, pduel->filter_allows_declaring_cards(options));
+	return 1;
+}
+LUA_STATIC_FUNCTION(AnnounceCard) {
+	check_action_permission(L);
+	check_param_count(L, 1);
+	auto playerid = lua_get<uint8_t>(L, 1);
+	auto& options = pduel->game_field->core.select_options;
+	options.clear();
+	get_opcodes(L, options, 2);
+	bool has_filter_opcodes = false;
+	if(!check_announceable(options, has_filter_opcodes))
+		lua_error(L, "Parameters are invalid.");
+	if(!has_filter_opcodes) {
 		options.push_back(TYPE_MONSTER | TYPE_SPELL | TYPE_TRAP);
 		options.push_back(OPCODE_ISTYPE);
 	}

--- a/ocgapi.cpp
+++ b/ocgapi.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, Dylam De La Torre, (DyXel)
- * Copyright (c) 2019-2025, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
+ * Copyright (c) 2019-2026, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -39,6 +39,10 @@ int OCG_CreateDuel(OCG_Duel* out_ocg_duel, const OCG_DuelOptions* options_ptr) {
 	if(options.cardReaderDone == nullptr) {
 		options.cardReaderDone = [](void* /*payload*/, OCG_CardData* /*data*/) {};
 		options.payload4 = nullptr;
+	}
+	if(options.existCardsToDeclare == nullptr) {
+		*out_ocg_duel = nullptr;
+		return OCG_DUEL_CREATION_NULL_DECLARATION_FILTER;
 	}
 	if(options.seed[0] == 0 && options.seed[1] == 0 && options.seed[2] == 0 && options.seed[3] == 0)
 		return OCG_DUEL_CREATION_NULL_RNG_SEED;

--- a/ocgapi_types.h
+++ b/ocgapi_types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2025, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
+ * Copyright (c) 2019-2026, Edoardo Lolletti (edo9300) <edoardo762@gmail.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -24,7 +24,8 @@ typedef enum OCG_DuelCreationStatus {
 	OCG_DUEL_CREATION_NULL_DATA_READER,
 	OCG_DUEL_CREATION_NULL_SCRIPT_READER,
 	OCG_DUEL_CREATION_INCOMPATIBLE_LUA_API,
-	OCG_DUEL_CREATION_NULL_RNG_SEED
+	OCG_DUEL_CREATION_NULL_RNG_SEED,
+	OCG_DUEL_CREATION_NULL_DECLARATION_FILTER
 }OCG_DuelCreationStatus;
 
 typedef enum OCG_DuelStatus {
@@ -60,6 +61,7 @@ typedef void (*OCG_DataReader)(void* payload, uint32_t code, OCG_CardData* data)
 typedef void (*OCG_DataReaderDone)(void* payload, OCG_CardData* data);
 typedef int (*OCG_ScriptReader)(void* payload, OCG_Duel duel, const char* name);
 typedef void (*OCG_LogHandler)(void* payload, const char* string, int type);
+typedef int (*OCG_ExistCardsToDeclare)(void* payload, const uint64_t* opcode_list, int opcode_num);
 
 typedef struct OCG_DuelOptions {
 	uint64_t seed[4];
@@ -74,6 +76,8 @@ typedef struct OCG_DuelOptions {
 	void* payload3; /* relayed to errorHandler */
 	OCG_DataReaderDone cardReaderDone;
 	void* payload4; /* relayed to cardReaderDone */
+	OCG_ExistCardsToDeclare existCardsToDeclare;
+	void* payload5; /* relayed to existCardsToDeclare */
 	uint8_t enableUnsafeLibraries;
 }OCG_DuelOptions;
 


### PR DESCRIPTION
A new ocgapi options parameter has been added `existCardsToDeclare`, which will return wether a list of opcodes allow for at least a card to be declared. This will be directly used by the new lua function `Duel.HasAnnounceableCard`.